### PR TITLE
Fix/ eliminate jumping scroll in home view

### DIFF
--- a/lib/config/map_view_config.dart
+++ b/lib/config/map_view_config.dart
@@ -36,8 +36,10 @@ abstract class MapWidgetConfig {
   );
   static const mapType = MapType.normal;
 
-  static const mapMarkerOriginWidth = 28;
-  static const activeMapMarkerOriginWidth = 40;
+  static const mapMarkerWidth = 22.0;
+  static const mapMarkerHeight = 34.0;
+  static const activeMapMarkerWidth = 30.4;
+  static const activeMapMarkerHeight = 46.4;
 }
 
 abstract class BuildingSearchConfig {

--- a/lib/config/transitions.dart
+++ b/lib/config/transitions.dart
@@ -3,9 +3,6 @@ import "package:auto_route/auto_route.dart";
 // TODO(simon-the-shark): adjust this settings if desired
 abstract class TransitionsConfig {
   static const durationInMiliseconds = 200;
-  static const detailDurationInMiliseconds = 200;
   static const slideLeftBuilder = TransitionsBuilders.slideLeftWithFade;
   static const slideRightBuilder = TransitionsBuilders.slideRightWithFade;
-  static const fallbackBuilder = TransitionsBuilders.fadeIn;
-  static const detailViewBuilder = TransitionsBuilders.slideBottom;
 }

--- a/lib/features/home_view/widgets/news_section.dart
+++ b/lib/features/home_view/widgets/news_section.dart
@@ -34,13 +34,19 @@ class _NewsList extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(newsRepositoryProvider);
+
     return switch (state) {
       AsyncLoading() => const Padding(
           padding: EdgeInsets.only(
             left: HomeViewConfig.paddingMedium,
-            top: HomeViewConfig.paddingMedium,
+            top: HomeViewConfig.paddingMedium *
+                2, // twice the padding of normal state, just to look cool
           ),
-          child: BigScrollableSectionLoading(),
+          child: SizedBox(
+            height:
+                BigPreviewCardConfig.cardHeight - HomeViewConfig.paddingMedium,
+            child: BigScrollableSectionLoading(),
+          ),
         ),
       AsyncError(:final error) => MyErrorWidget(error),
       AsyncValue(:final value) => Column(

--- a/lib/features/map_view/utils/map_marker_utils.dart
+++ b/lib/features/map_view/utils/map_marker_utils.dart
@@ -1,7 +1,4 @@
-import "dart:ui" as ui;
-
 import "package:flutter/foundation.dart";
-import "package:flutter/services.dart";
 import "package:flutter/widgets.dart";
 import "package:google_maps_flutter/google_maps_flutter.dart";
 
@@ -15,47 +12,42 @@ class MapMarkerUtils {
   static late final BitmapDescriptor activeParkingMapMarker;
 
   static Future<void> loadMapMarkerAssets(BuildContext context) async {
-    final pixelRatio =
-        kIsWeb ? 1 : MediaQuery.devicePixelRatioOf(context).toInt();
-
-    buildingMapMarker = await _AssetScaledLoader.loadScaledBitmapDescriptor(
+    final configuration = context.mapMarkerConfiguration;
+    final activeMarkerConfig = context.activeMapMarkerConfiguration;
+    buildingMapMarker = await BitmapDescriptor.asset(
+      configuration,
       Assets.mapMarkers.mapMarker.path,
-      width: MapWidgetConfig.mapMarkerOriginWidth * pixelRatio,
     );
-
-    activeBuildingMapMarker =
-        await _AssetScaledLoader.loadScaledBitmapDescriptor(
+    activeBuildingMapMarker = await BitmapDescriptor.asset(
+      activeMarkerConfig,
       Assets.mapMarkers.activeMapMarker.path,
-      width: MapWidgetConfig.activeMapMarkerOriginWidth * pixelRatio,
     );
-    parkingMapMarker = await _AssetScaledLoader.loadScaledBitmapDescriptor(
+    parkingMapMarker = await BitmapDescriptor.asset(
+      configuration,
       Assets.mapMarkers.parkingMapMarker.path,
-      width: MapWidgetConfig.mapMarkerOriginWidth * pixelRatio,
     );
-    activeParkingMapMarker =
-        await _AssetScaledLoader.loadScaledBitmapDescriptor(
+    activeParkingMapMarker = await BitmapDescriptor.asset(
+      activeMarkerConfig,
       Assets.mapMarkers.activeParkingMapMarker.path,
-      width: MapWidgetConfig.activeMapMarkerOriginWidth * pixelRatio,
     );
   }
 }
 
-class _AssetScaledLoader {
-  static Future<BitmapDescriptor> loadScaledBitmapDescriptor(
-    String assetName, {
-    required int width,
-  }) async {
-    try {
-      final data = await rootBundle.load(assetName);
-      final codec = await ui.instantiateImageCodec(
-        data.buffer.asUint8List(),
-        targetWidth: width,
+extension _ImageConfigurationX on BuildContext {
+  double get pixelRatio => kIsWeb ? 1.0 : MediaQuery.devicePixelRatioOf(this);
+
+  ImageConfiguration get mapMarkerConfiguration => ImageConfiguration(
+        devicePixelRatio: pixelRatio,
+        size: const Size(
+          MapWidgetConfig.mapMarkerWidth,
+          MapWidgetConfig.mapMarkerHeight,
+        ),
       );
-      final fi = await codec.getNextFrame();
-      final decode = await fi.image.toByteData(format: ui.ImageByteFormat.png);
-      return BitmapDescriptor.bytes(decode!.buffer.asUint8List());
-    } on Exception {
-      return BitmapDescriptor.defaultMarker; // fallback
-    }
-  }
+  ImageConfiguration get activeMapMarkerConfiguration => ImageConfiguration(
+        devicePixelRatio: pixelRatio,
+        size: const Size(
+          MapWidgetConfig.activeMapMarkerWidth,
+          MapWidgetConfig.activeMapMarkerHeight,
+        ),
+      );
 }

--- a/lib/features/navigator/app_router.dart
+++ b/lib/features/navigator/app_router.dart
@@ -1,5 +1,4 @@
 import "package:auto_route/auto_route.dart";
-import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
@@ -67,14 +66,9 @@ class AppRouter extends _$AppRouter {
               transitionsBuilder:
                   ref.tabBarTransitionBuilder(DepartmentsRoute.name),
             ),
-            CustomRoute(
+            AutoRoute(
               path: "departments/:id",
               page: DepartmentDetailRoute.page,
-              durationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              reverseDurationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              transitionsBuilder: TransitionsConfig.detailViewBuilder,
             ),
             CustomRoute(
               path: "sci-clubs",
@@ -85,14 +79,9 @@ class AppRouter extends _$AppRouter {
               transitionsBuilder:
                   ref.tabBarTransitionBuilder(ScienceClubsRoute.name),
             ),
-            CustomRoute(
+            AutoRoute(
               path: "sci-clubs/:id",
               page: ScienceClubDetailRoute.page,
-              durationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              reverseDurationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              transitionsBuilder: TransitionsConfig.detailViewBuilder,
             ),
             CustomRoute(
               path: "guide",
@@ -102,14 +91,9 @@ class AppRouter extends _$AppRouter {
                   TransitionsConfig.durationInMiliseconds,
               transitionsBuilder: ref.tabBarTransitionBuilder(GuideRoute.name),
             ),
-            CustomRoute(
+            AutoRoute(
               path: "aboutUs",
               page: AboutUsRoute.page,
-              durationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              reverseDurationInMilliseconds:
-                  TransitionsConfig.detailDurationInMiliseconds,
-              transitionsBuilder: TransitionsConfig.detailViewBuilder,
             ),
           ],
         ),

--- a/lib/widgets/loading_widgets/specific_imitations/big_preview_card_loading.dart
+++ b/lib/widgets/loading_widgets/specific_imitations/big_preview_card_loading.dart
@@ -16,7 +16,7 @@ class BigPreviewCardLoading extends StatelessWidget {
           ShimmerLoadingItem(
             child: Container(
               width: BigPreviewCardConfig.cardWidth,
-              height: 135,
+              height: 155,
               decoration: BoxDecoration(
                 color: Colors.white,
                 borderRadius: BorderRadius.circular(8),
@@ -35,13 +35,22 @@ class _LoadingText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const gap = 22.5;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 16),
-        PreviewTextPrototype(width: BigPreviewCardConfig.cardWidth),
-        const SizedBox(height: 16),
-        PreviewTextPrototype(width: BigPreviewCardConfig.cardWidth / 1.5),
+        const SizedBox(height: gap),
+        PreviewTextPrototype(width: BigPreviewCardConfig.cardWidth, height: 25),
+        const SizedBox(height: gap),
+        PreviewTextPrototype(
+          width: BigPreviewCardConfig.cardWidth / 1.3,
+          height: 25,
+        ),
+        const SizedBox(height: gap),
+        PreviewTextPrototype(
+          width: BigPreviewCardConfig.cardWidth / 2.5,
+          height: 25,
+        ),
       ],
     );
   }


### PR DESCRIPTION
Don't be scared with stacked PRs :) this one is very simple. Just make reviews of every one of them and I'll merge them in the end together.

# FIx of #104 
- Actually it is observable on android too, but android has a bit different scroll mechanics, so in ios it was more obvious
- very simple fix, just as I anticipated, one section had different hight while loading than in loaded state and with `ListView.builder` it was rebuilding just in that specific moment and trigger the rebuild and weird scroll mechanics.
- Fixed with simple calculations and sized box.

# Previews
## Issue (before changes)


https://github.com/user-attachments/assets/3f5303c6-4758-4e30-8a1f-e07f44191e46


## Results

https://github.com/user-attachments/assets/3056ea0c-c801-4b1a-aba4-d172eed9c8f5


# Changes. 
## News section. 
this was main problem.  
### Loaded state (no changes). 

<img width="450" alt="Zrzut ekranu 2024-08-3 o 14 58 14" src="https://github.com/user-attachments/assets/c2189b48-eccc-4570-8314-a6ec6f231643">

### Loading state BEFORE. 

<img width="503" alt="Zrzut ekranu 2024-08-3 o 14 59 21" src="https://github.com/user-attachments/assets/6b92c583-8543-4afb-abbe-292684d4586e">

### Loading state AFTER. 

<img width="479" alt="Zrzut ekranu 2024-08-3 o 15 22 16" src="https://github.com/user-attachments/assets/ccd43f89-3da1-4a0f-9f5b-32a68faf82b7">

# Alternative
Alternative solution is to preserve `newsRepository` provider in the memory, either with `keepAlive: true` (don't like the idea) or just subscribing to it in the lower section of the home view (feel very hacky). But if you think current loading looks significatly worse, we can solve this this way too.