### PR TITLE
Feat/143 implement deparments links sorting

### DIFF
--- a/lib/config/contact_icons.dart
+++ b/lib/config/contact_icons.dart
@@ -11,5 +11,16 @@ abstract class ContactIconsConfig {
     "maps": Assets.contactIcons.compass,
     "tel": Assets.contactIcons.phone,
   };
+  static final iconsOrder = {
+    "maps": 1,
+    "tel": 2,
+    "mailto:": 3,
+    "linkedin": 5,
+    "facebook": 6,
+    "instagram": 7,
+    "youtu": 8,
+    "github": 9,
+  };
+  static const defaultIconOrder = 4;
   static final defaultIcon = Assets.contactIcons.web;
 }

--- a/lib/utils/determine_contact_icon.dart
+++ b/lib/utils/determine_contact_icon.dart
@@ -8,11 +8,13 @@ class ContactIconsModel {
   final String icon;
   final String? text;
   final String? url;
+  final int order;
 
   ContactIconsModel({
     String? text,
     this.url,
   })  : icon = url.determineIcon(),
+        order = url.determineIconOrder(),
         text = text ?? url;
 }
 
@@ -26,5 +28,15 @@ extension IconDeterminerX on String? {
                 ?.value ??
             ContactIconsConfig.defaultIcon
         : ContactIconsConfig.defaultIcon;
+  }
+  int determineIconOrder() {
+    return this != null
+        ? ContactIconsConfig.iconsOrder.entries
+                .firstWhereOrNull(
+                  (e) => this!.contains(e.key),
+                )
+                ?.value ??
+            ContactIconsConfig.defaultIconOrder
+        : ContactIconsConfig.defaultIconOrder;
   }
 }

--- a/lib/utils/determine_contact_icon.dart
+++ b/lib/utils/determine_contact_icon.dart
@@ -29,6 +29,7 @@ extension IconDeterminerX on String? {
             ContactIconsConfig.defaultIcon
         : ContactIconsConfig.defaultIcon;
   }
+
   int determineIconOrder() {
     return this != null
         ? ContactIconsConfig.iconsOrder.entries

--- a/lib/widgets/detail_views/contact_section.dart
+++ b/lib/widgets/detail_views/contact_section.dart
@@ -14,6 +14,7 @@ class ContactSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    list.sort((a, b) => a.order.compareTo(b.order));
     return Container(
       padding: const EdgeInsets.only(top: 24, left: 24, right: 24, bottom: 8),
       color: context.colorTheme.greyLight,


### PR DESCRIPTION

### New order of icons in contact section widget

1. Location on map 
2. Telephone number(s)
3. E-mail
4. Website
5. LinkedIn
6. Facebook 
7. Instagram
8. YouTube
9. GitHub


### Notes

Current order is only my "vision" of how it could look like. I'm not devoted to it. 