### PR TITLE
#124 - parking typos - fix

### DIFF
--- a/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
+++ b/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart";
 import "../../../config/ui_config.dart";
 import "../../../theme/app_theme.dart";
 import "../../../theme/iparking_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "../../parking_chart/parking_chart.dart";
 import "../models/parking.dart";
 import "parkings_icons.icons.dart";
@@ -79,7 +80,7 @@ class _LeftColumn extends StatelessWidget {
           padding: ParkingsConfig.extraIndentPadd,
           child: isActive
               ? Text(
-                  parking.addresFormatted,
+                  "${context.localize.street_abbreviation} ${parking.address}",
                   style: context.iParkingTheme.subtitleLight.withoutShadows,
                 )
               : Text(

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -88,5 +88,6 @@
   "categories":"Kategorie tematyczne",
   "filters" : "Filtry",
   "clear" : "Wyczyść",
-  "filters_didnt_found_anything" : "Nie znaleziono żadnych filtrów"
+  "filters_didnt_found_anything" : "Nie znaleziono żadnych filtrów",
+  "street_abbreviation" : "ul."
 }


### PR DESCRIPTION
At first glance, I thought about setting the street address in the data layer, but then I thought about localization and finally ended up setting the "ul. "  or "st. " prefix in the ui layer. 

<img src="https://github.com/user-attachments/assets/55296f8b-f41d-44ee-9744-eee274a65d23" alt="Screenshot" width="300"/>


