### PR TITLE
#164 - add splash on field of study tile

### DIFF
--- a/lib/widgets/wide_tile_card.dart
+++ b/lib/widgets/wide_tile_card.dart
@@ -49,31 +49,36 @@ class WideTileCard extends StatelessWidget {
   final List<BoxShadow>? activeShadows;
   final LinearGradient? activeGradient;
   final CrossAxisAlignment crossAxisAlignment;
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        decoration: BoxDecoration(
-          gradient: isActive ? activeGradient : null,
-          color: context.colorTheme.greyLight,
+    return ClipRRect(
+      child: Material(
+        child: InkWell(
           borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
-          boxShadow: isActive ? activeShadows : null,
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: Row(
-          crossAxisAlignment: crossAxisAlignment,
-          children: [
-            Expanded(
-              child: _TitlesColumn(
-                title,
-                subtitle,
-                secondSubtitle,
-                isActive: isActive,
-              ),
+          onTap: onTap,
+          child: Ink(
+            decoration: BoxDecoration(
+              gradient: isActive ? activeGradient : null,
+              color: context.colorTheme.greyLight,
+              borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
+              boxShadow: isActive ? activeShadows : null,
             ),
-            if (trailing != null) trailing!,
-          ],
+            child: Row(
+              crossAxisAlignment: crossAxisAlignment,
+              children: [
+                Expanded(
+                  child: _TitlesColumn(
+                    title,
+                    subtitle,
+                    secondSubtitle,
+                    isActive: isActive,
+                  ),
+                ),
+                if (trailing != null) trailing!,
+              ],
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
# About
Splash now works correctly on fields of study tile and on building tile (used in map view)

# Preview

### Splash on field of study tile
[splash_departments.webm](https://github.com/user-attachments/assets/3053db8e-b14f-4e1f-a3d0-0a71fb0ff976)

### Splash on buildings tile
[splash_buildings.webm](https://github.com/user-attachments/assets/11641950-4da5-44cd-9fd3-d39db9beda85)

