### PR TITLE
Refactor/`IList` and nullstafety tweaks

### DIFF
--- a/lib/features/about_us_view/about_us_view.dart
+++ b/lib/features/about_us_view/about_us_view.dart
@@ -8,6 +8,7 @@ import "../../utils/context_extensions.dart";
 import "../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../widgets/detail_views/sliver_header_section.dart";
 import "../../widgets/my_error_widget.dart";
+import "models/about_us_details.dart";
 import "repository/about_us_repository.dart";
 import "widgets/contact_section.dart";
 import "widgets/description_section.dart";
@@ -35,32 +36,27 @@ class _AboutUsView extends ConsumerWidget {
     final state = ref.watch(aboutUsRepositoryProvider);
 
     return switch (state) {
-      AsyncLoading() => Center(
-          child: CircularProgressIndicator(
-            color: context.colorTheme.orangePomegranade,
-          ),
-        ),
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => CustomScrollView(
+      AsyncValue(:final AboutUsDetails value) => CustomScrollView(
           slivers: [
             SliverPersistentHeader(
               delegate: SliverHeaderSection(
                 logoDirectusImageUrl: AboutUsConfig.defaultLogoUrl,
-                backgroundImageUrl: value?.aboutUs?.cover?.filename_disk,
+                backgroundImageUrl: value.aboutUs?.cover?.filename_disk,
               ),
             ),
             SliverList(
               delegate: SliverChildListDelegate(
                 [
                   SectionHeader(text: context.localize.about_us),
-                  DescriptionSection(text: value?.aboutUs?.description ?? ""),
+                  DescriptionSection(text: value.aboutUs?.description ?? ""),
                   SectionHeader(text: context.localize.meet_our_team),
                   TeamSection(
-                    members: value?.getMemberData() ?? [],
+                    members: value.getMemberData(),
                   ),
                   SectionHeader(text: context.localize.follow_solvro),
                   ContactSection(
-                    links: value?.getSocialIcons() ?? [],
+                    links: value.getSocialIcons(),
                   ),
                   const SizedBox(
                     height: AboutUsConfig.spacerHeight,
@@ -69,6 +65,11 @@ class _AboutUsView extends ConsumerWidget {
               ),
             ),
           ],
+        ),
+      _ => Center(
+          child: CircularProgressIndicator(
+            color: context.colorTheme.orangePomegranade,
+          ),
         ),
     };
   }

--- a/lib/features/about_us_view/models/about_us_details.dart
+++ b/lib/features/about_us_view/models/about_us_details.dart
@@ -1,3 +1,5 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+
 import "../../../utils/determine_contact_icon.dart";
 import "../../../utils/where_non_null_iterable.dart";
 import "../repository/about_us_repository.dart";
@@ -5,27 +7,27 @@ import "member_data.dart";
 
 class AboutUsDetails {
   final AboutUs? aboutUs;
-  final List<AboutUsTeam>? aboutUsTeam;
+  final IList<AboutUsTeam> aboutUsTeam;
 
-  AboutUsDetails({this.aboutUs, this.aboutUsTeam});
+  AboutUsDetails({required this.aboutUs, required this.aboutUsTeam});
 
-  List<MemberData> getMemberData() {
-    return aboutUsTeam.whereNonNull.map((e) {
+  IList<MemberData> getMemberData() {
+    return aboutUsTeam.map((e) {
       return MemberData(
         name: e.name,
         directusImageUrl: e.photo?.filename_disk,
-        socialLinks: e.socialLinks.whereNonNull.map((e) => e.url).toList(),
+        socialLinks: e.socialLinks.whereNonNull.map((e) => e.url).toIList(),
         subtitle: e.subtitle,
       );
-    }).toList();
+    }).toIList();
   }
 
-  List<ContactIconsModel> getSocialIcons() {
-    return aboutUs?.solvroSocialLinks.whereNonNull
-            .map(
-              (e) => ContactIconsModel(url: e.url),
-            )
-            .toList() ??
-        [];
+  IList<ContactIconsModel> getSocialIcons() {
+    return (aboutUs?.solvroSocialLinks)
+        .whereNonNull
+        .map(
+          (e) => ContactIconsModel(url: e.url),
+        )
+        .toIList();
   }
 }

--- a/lib/features/about_us_view/models/member_data.dart
+++ b/lib/features/about_us_view/models/member_data.dart
@@ -1,13 +1,14 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/foundation.dart";
 
 import "../../../utils/determine_contact_icon.dart";
 
 @immutable
 class MemberData {
-  final List<String> socialLinks;
+  final IList<String> socialLinks;
   final String? name;
   final String? subtitle;
-  final List<ContactIconsModel> links;
+  final IList<ContactIconsModel> links;
   final String? directusImageUrl;
 
   MemberData({
@@ -17,8 +18,8 @@ class MemberData {
     required this.directusImageUrl,
   }) : links = _determineLinksIcons(socialLinks);
 
-  static List<ContactIconsModel> _determineLinksIcons(List<String> urls) {
-    return urls.map((url) => ContactIconsModel(url: url)).toList();
+  static IList<ContactIconsModel> _determineLinksIcons(IList<String> urls) {
+    return urls.map((url) => ContactIconsModel(url: url)).toIList();
   }
 
   @override
@@ -26,10 +27,10 @@ class MemberData {
     if (identical(this, other)) return true;
 
     return other is MemberData &&
-        listEquals(other.socialLinks, socialLinks) &&
+        other.socialLinks == socialLinks &&
         other.name == name &&
         other.subtitle == subtitle &&
-        listEquals(other.links, links) &&
+        other.links == links &&
         other.directusImageUrl == directusImageUrl;
   }
 

--- a/lib/features/about_us_view/repository/about_us_repository.dart
+++ b/lib/features/about_us_view/repository/about_us_repository.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
@@ -19,6 +20,6 @@ Future<AboutUsDetails?> aboutUsRepository(AboutUsRepositoryRef ref) async {
   if (results == null) return null;
   return AboutUsDetails(
     aboutUs: results.AboutUs,
-    aboutUsTeam: results.AboutUs_Team,
+    aboutUsTeam: results.AboutUs_Team.lock,
   );
 }

--- a/lib/features/about_us_view/widgets/contact_section.dart
+++ b/lib/features/about_us_view/widgets/contact_section.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:flutter_svg/svg.dart";
@@ -10,7 +11,7 @@ import "../../../utils/launch_url_util.dart";
 class ContactSection extends StatelessWidget {
   const ContactSection({super.key, required this.links});
 
-  final List<ContactIconsModel> links;
+  final IList<ContactIconsModel> links;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:flutter_svg/svg.dart";
@@ -11,7 +12,7 @@ import "../models/member_data.dart";
 
 class TeamSection extends StatelessWidget {
   const TeamSection({super.key, required this.members});
-  final List<MemberData> members;
+  final IList<MemberData> members;
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +91,7 @@ class _Description extends StatelessWidget {
   });
   final String name;
   final String subtitle;
-  final List<ContactIconsModel> links;
+  final IList<ContactIconsModel> links;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/academic_calendar/model/academic_week_exception.dart
+++ b/lib/features/academic_calendar/model/academic_week_exception.dart
@@ -1,11 +1,12 @@
 import "package:collection/collection.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
 import "../../../utils/datetime_utils.dart";
 import "../repository/academic_calendar_repo.dart";
 import "academic_day.dart";
 import "weekday_enum.dart";
 
-extension AcademicWeekExceptionX on List<AcademicWeekException> {
+extension AcademicWeekExceptionX on IList<AcademicWeekException> {
   bool _checkIfThisIsToday(AcademicWeekException element) =>
       element.day.isSameDay(now);
 

--- a/lib/features/academic_calendar/repository/academic_calendar_repo.dart
+++ b/lib/features/academic_calendar/repository/academic_calendar_repo.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
@@ -20,5 +21,5 @@ Future<AcademicCalendar?> academicCalendarRepo(AcademicCalendarRepoRef ref) {
 
 extension FixNestedTypesX on AcademicCalendar {
   AcademicCalendarData? get data => this.AcademicCalendarData;
-  List<AcademicWeekException> get weeks => WeekExceptions;
+  IList<AcademicWeekException> get weeks => WeekExceptions.lock;
 }

--- a/lib/features/bottom_scroll_sheet/data_list.dart
+++ b/lib/features/bottom_scroll_sheet/data_list.dart
@@ -4,7 +4,6 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../config/map_view_config.dart";
 import "../../theme/app_theme.dart";
-import "../../utils/where_non_null_iterable.dart";
 import "../../widgets/my_error_widget.dart";
 import "../map_view/controllers/controllers_set.dart";
 import "../map_view/widgets/map_config.dart";
@@ -17,10 +16,7 @@ class DataSliverList<T extends GoogleNavigable> extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final itemsState = ref.watch(context.mapDataController<T>());
     return switch (itemsState) {
-      // misz-masz here fixed flickering
-      // we probably should consider similar refactoring to all switches, but won't be visible in our other use-cases
-      AsyncValue(:final IList<T?> value) =>
-        _DataSliverList<T>(value.whereNonNull.toIList()),
+      AsyncValue(:final IList<T> value) => _DataSliverList<T>(value),
       AsyncError(:final error) =>
         SliverToBoxAdapter(child: MyErrorWidget(error)),
       _ => const DataListLoading(),

--- a/lib/features/bottom_scroll_sheet/data_list.dart
+++ b/lib/features/bottom_scroll_sheet/data_list.dart
@@ -16,9 +16,9 @@ class DataSliverList<T extends GoogleNavigable> extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final itemsState = ref.watch(context.mapDataController<T>());
     return switch (itemsState) {
-      AsyncValue(:final IList<T> value) => _DataSliverList<T>(value),
       AsyncError(:final error) =>
         SliverToBoxAdapter(child: MyErrorWidget(error)),
+      AsyncValue(:final IList<T> value) => _DataSliverList<T>(value),
       _ => const DataListLoading(),
     };
   }

--- a/lib/features/buildings_view/controllers.dart
+++ b/lib/features/buildings_view/controllers.dart
@@ -30,7 +30,7 @@ class BuildingsViewController extends _$BuildingsViewController
   }
   @override
   // ignore: unnecessary_overrides
-  FutureOr<IList<BuildingModel?>?> build() async {
+  FutureOr<IList<BuildingModel>> build() async {
     return super.build();
   }
 

--- a/lib/features/buildings_view/repository/buildings_repository.dart
+++ b/lib/features/buildings_view/repository/buildings_repository.dart
@@ -3,6 +3,7 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../config/ttl_config.dart";
 import "../../../api_base/query_adapter.dart";
+import "../../../utils/ilist_nonempty.dart";
 import "../model/building_model.dart";
 import "getBuildings.graphql.dart";
 
@@ -11,12 +12,12 @@ part "buildings_repository.g.dart";
 typedef Building = Query$GetBuildings$Buildings;
 
 @riverpod
-Future<IList<BuildingModel?>?> buildingsRepository(
+Future<IList<BuildingModel>> buildingsRepository(
   BuildingsRepositoryRef ref,
 ) async {
   final results = await ref.queryGraphql(
     Options$Query$GetBuildings(),
     TtlKey.buildingsRepository,
   );
-  return results?.Buildings.map(BuildingModel.from).toIList();
+  return (results?.Buildings.map(BuildingModel.from)).toIList();
 }

--- a/lib/features/department_detail_view/department_detail_view.dart
+++ b/lib/features/department_detail_view/department_detail_view.dart
@@ -30,15 +30,14 @@ class DepartmentDetailView extends ConsumerWidget {
     return Scaffold(
       appBar: DetailViewAppBar(context, title: context.localize.departments),
       body: switch (state) {
-        AsyncLoading() => const DepartmentDetailViewLoading(),
         AsyncError(:final error) => MyErrorWidget(error),
-        AsyncValue(:final value) => CustomScrollView(
+        AsyncValue(:final DepartmentDetails value) => CustomScrollView(
             slivers: [
               SliverPersistentHeader(
                 delegate: DepartmentSliverHeaderSection(
-                  activeGradient: value?.Departments_by_id?.gradient,
+                  activeGradient: value.Departments_by_id?.gradient,
                   logoDirectusImageUrl:
-                      value?.Departments_by_id?.logo?.filename_disk,
+                      value.Departments_by_id?.logo?.filename_disk,
                 ),
               ),
               SliverList(
@@ -47,7 +46,7 @@ class DepartmentDetailView extends ConsumerWidget {
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 24),
                     child: Text(
-                      value?.Departments_by_id?.name ?? "",
+                      value.Departments_by_id?.name ?? "",
                       style: context.textTheme.headline,
                       textAlign: TextAlign.center,
                       maxLines: 2,
@@ -55,8 +54,7 @@ class DepartmentDetailView extends ConsumerWidget {
                   ),
                   const SizedBox(height: 12),
                   Text(
-                    value?.Departments_by_id?.address
-                            ?.divideAddressInto3Lines ??
+                    value.Departments_by_id?.address?.divideAddressInto3Lines ??
                         "",
                     style: context.textTheme.body.copyWith(height: 1.2),
                     textAlign: TextAlign.center,
@@ -64,18 +62,18 @@ class DepartmentDetailView extends ConsumerWidget {
                   const SizedBox(height: DetailViewsConfig.spacerHeight),
                   ContactSection(
                     title: context.localize.deans_office,
-                    list: value?.Departments_by_id?.links.whereNonNull
-                            .map(
-                              (link) => ContactIconsModel(
-                                text: link.name,
-                                url: link.link,
-                              ),
-                            )
-                            .toList() ??
-                        List.empty(),
+                    list: (value.Departments_by_id?.links)
+                        .whereNonNull
+                        .map(
+                          (link) => ContactIconsModel(
+                            text: link.name,
+                            url: link.link,
+                          ),
+                        )
+                        .toIList(),
                   ),
                   FieldsOfStudySection(
-                    fieldsOfStudy: (value?.Departments_by_id?.fieldsOfStudies)
+                    fieldsOfStudy: (value.Departments_by_id?.fieldsOfStudies)
                         .whereNonNull
                         .toIList(),
                   ),
@@ -85,6 +83,7 @@ class DepartmentDetailView extends ConsumerWidget {
               ),
             ],
           ),
+        _ => const DepartmentDetailViewLoading(),
       },
     );
   }

--- a/lib/features/department_detail_view/widgets/science_clubs_section.dart
+++ b/lib/features/department_detail_view/widgets/science_clubs_section.dart
@@ -16,7 +16,7 @@ import "../../science_clubs_filters/filters_controller.dart";
 import "../../science_clubs_view/repository/science_clubs_repository.dart";
 import "../repository/department_details_repository.dart";
 
-// TODO(simon-the-shark): Resolve if the list button should redirect to list of all study circles or only ones related to the department.
+// TODO(simon-the-shark): Resolve if the list button should redirect to list of all study circles or only ones related to the department., #165
 class DepartmentScienceClubsSection extends ConsumerWidget {
   const DepartmentScienceClubsSection(this.department, {super.key});
   final DepartmentDetails? department;

--- a/lib/features/departments_view/departments_view.dart
+++ b/lib/features/departments_view/departments_view.dart
@@ -5,7 +5,6 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../config/ui_config.dart";
 import "../../utils/context_extensions.dart";
-import "../../utils/where_non_null_iterable.dart";
 import "../../widgets/my_error_widget.dart";
 import "../../widgets/search_box_app_bar.dart";
 import "../../widgets/search_not_found.dart";
@@ -44,8 +43,8 @@ class _DepartmentsViewListBody extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: switch (state) {
         AsyncError(:final error) => MyErrorWidget(error),
-        AsyncValue(:final IList<Department?> value) =>
-          _DepartmentsDataView(value.whereNonNull.toList()),
+        AsyncValue(:final IList<Department> value) =>
+          _DepartmentsDataView(value),
         _ => const DepartmentsViewLoading(),
       },
     );
@@ -55,7 +54,7 @@ class _DepartmentsViewListBody extends ConsumerWidget {
 class _DepartmentsDataView extends ConsumerWidget {
   const _DepartmentsDataView(this.departments);
 
-  final List<Department> departments;
+  final IList<Department> departments;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/departments_view/departments_view_controllers.dart
+++ b/lib/features/departments_view/departments_view_controllers.dart
@@ -17,7 +17,7 @@ class SearchDepartmentsController extends _$SearchDepartmentsController {
 }
 
 @riverpod
-Future<IList<Department?>> departmentsList(DepartmentsListRef ref) async {
+Future<IList<Department>> departmentsList(DepartmentsListRef ref) async {
   final originalList = await ref.watch(departmentsRepositoryProvider.future);
   final query = ref.watch(searchDepartmentsControllerProvider);
   return originalList

--- a/lib/features/departments_view/repository/departments_repository.dart
+++ b/lib/features/departments_view/repository/departments_repository.dart
@@ -1,7 +1,9 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
 import "../../../config/ttl_config.dart";
+import "../../../utils/ilist_nonempty.dart";
 import "departments_extensions.dart";
 import "getDepartments.graphql.dart";
 
@@ -10,12 +12,12 @@ part "departments_repository.g.dart";
 typedef Department = Query$GetDepartments$Departments;
 
 @riverpod
-Future<List<Department>> departmentsRepository(
+Future<IList<Department>> departmentsRepository(
   DepartmentsRepositoryRef ref,
 ) async {
   final results = await ref.queryGraphql(
     Options$Query$GetDepartments(),
     TtlKey.departmentsRepository,
   );
-  return (results?.Departments?..sortByCodeOrder()) ?? [];
+  return (results?.Departments?..sortByCodeOrder()).toIList();
 }

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -41,16 +41,15 @@ class _GuideDetailDataView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(guideDetailsRepositoryProvider(id));
     return switch (state) {
-      AsyncLoading() => const _GuideDetailLoading(),
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => CustomScrollView(
+      AsyncValue(:final GuideDetails value) => CustomScrollView(
           slivers: [
             SliverAppBar(
               expandedHeight: 254,
               flexibleSpace: SizedBox(
                 height: 254,
                 child: OptimizedDirectusImage(
-                  value?.cover?.filename_disk,
+                  value.cover?.filename_disk,
                 ),
               ),
               automaticallyImplyLeading: false,
@@ -58,7 +57,7 @@ class _GuideDetailDataView extends ConsumerWidget {
             SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.all(24),
-                child: MyHtmlWidget(value?.description ?? ""),
+                child: MyHtmlWidget(value.description ?? ""),
               ),
             ),
             SliverPadding(
@@ -66,9 +65,9 @@ class _GuideDetailDataView extends ConsumerWidget {
                 bottom: GuideDetailViewConfig.paddingLarge,
               ),
               sliver: SliverList.separated(
-                itemCount: value?.questions?.length ?? 0,
+                itemCount: value.questions?.length ?? 0,
                 itemBuilder: (context, index) {
-                  final question = value?.questions?[index]?.FAQ_id;
+                  final question = value.questions?[index]?.FAQ_id;
                   return FaqExpansionTile(
                     title: question?.question ?? "",
                     description: question?.answer ?? "",
@@ -79,6 +78,7 @@ class _GuideDetailDataView extends ConsumerWidget {
             ),
           ],
         ),
+      _ => const _GuideDetailLoading(),
     };
   }
 }

--- a/lib/features/guide_view/guide_view.dart
+++ b/lib/features/guide_view/guide_view.dart
@@ -6,7 +6,6 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../../../widgets/my_error_widget.dart";
 import "../../config/ui_config.dart";
 import "../../utils/context_extensions.dart";
-import "../../utils/where_non_null_iterable.dart";
 import "../../widgets/search_box_app_bar.dart";
 import "../analytics/show_feedback_tile.dart";
 import "../departments_view/widgets/departments_view_loading.dart";
@@ -44,12 +43,12 @@ class _GuideViewContent extends ConsumerWidget {
 
     return switch (guideList) {
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final IList<GuidePost?> value) => GuideGrid(
+      AsyncValue(:final IList<GuidePost> value) => GuideGrid(
           children: [
             if (!isSomethingSearched) const GuideAboutUsSection(),
-            for (final item in value.whereNonNull) GuideTile(item),
+            for (final item in value) GuideTile(item),
             if (!isSomethingSearched) const ShowFeedbackTile(),
-          ],
+          ].lock,
         ),
       _ => const Padding(
           padding: GuideViewConfig.gridPadding,

--- a/lib/features/guide_view/guide_view_controller.dart
+++ b/lib/features/guide_view/guide_view_controller.dart
@@ -22,14 +22,14 @@ bool isSomethingSearched(IsSomethingSearchedRef ref) {
 }
 
 @riverpod
-Future<IList<GuidePost?>?> guideListController(
+Future<IList<GuidePost>> guideListController(
   GuideListControllerRef ref,
 ) async {
   final originalList = await ref.watch(guideRepositoryProvider.future);
   final query = ref.watch(searchGuideControllerProvider);
   return originalList
-      ?.where(
-        (element) => element == null || element.name.containsLowerCase(query),
+      .where(
+        (element) => element.name.containsLowerCase(query),
       )
       .toIList();
 }

--- a/lib/features/guide_view/repository/guide_repository.dart
+++ b/lib/features/guide_view/repository/guide_repository.dart
@@ -3,6 +3,7 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
 import "../../../config/ttl_config.dart";
+import "../../../utils/ilist_nonempty.dart";
 import "getGuide.graphql.dart";
 
 part "guide_repository.g.dart";
@@ -10,10 +11,10 @@ part "guide_repository.g.dart";
 typedef GuidePost = Query$GetGuide$FAQ_Types;
 
 @riverpod
-Future<IList<GuidePost?>?> guideRepository(GuideRepositoryRef ref) async {
+Future<IList<GuidePost>> guideRepository(GuideRepositoryRef ref) async {
   final results = await ref.queryGraphql(
     Options$Query$GetGuide(),
     TtlKey.guideRepository,
   );
-  return results?.FAQ_Types.toIList();
+  return (results?.FAQ_Types).toIList();
 }

--- a/lib/features/guide_view/widgets/guide_grid.dart
+++ b/lib/features/guide_view/widgets/guide_grid.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/cupertino.dart";
 
 import "../../../config/ui_config.dart";
@@ -7,7 +8,7 @@ import "../../../widgets/search_not_found.dart";
 class GuideGrid extends StatelessWidget {
   const GuideGrid({super.key, required this.children});
 
-  final List<Widget> children;
+  final IList<Widget> children;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -1,4 +1,5 @@
 import "package:auto_route/auto_route.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 
 import "../../config/ui_config.dart";
@@ -18,14 +19,14 @@ class HomeView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final List<Widget> sections = [
+    final sections = [
       const AcademicCalendarConsumer(),
       const ParkingsSection(),
       const ScienceClubsSection(),
       const BuildingsSection(),
       const NewsSection(),
       const DepartmentsSection(),
-    ];
+    ].lock;
     return Scaffold(
       backgroundColor: context.colorTheme.whiteSoap,
       appBar: LogoAppBar(context),

--- a/lib/features/home_view/widgets/buildings_section/buildings_section.dart
+++ b/lib/features/home_view/widgets/buildings_section/buildings_section.dart
@@ -1,8 +1,8 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../../utils/context_extensions.dart";
-import "../../../../utils/where_non_null_iterable.dart";
 import "../../../../widgets/my_error_widget.dart";
 import "../../../../widgets/subsection_header.dart";
 import "../../../buildings_view/model/building_model.dart";
@@ -35,16 +35,16 @@ class _BuildingsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(buildingsRepositoryProvider);
     return switch (state) {
-      AsyncLoading() => const MediumLeftPadding(
-          child: ScrollableSectionLoading(),
-        ),
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => SmallHorizontalPadding(
+      AsyncValue(:final IList<BuildingModel> value) => SmallHorizontalPadding(
           child: SizedBox(
             height: 120,
-            child: _DataListBuildingsTiles(value.whereNonNull.toList()),
+            child: _DataListBuildingsTiles(value),
           ),
-        )
+        ),
+      _ => const MediumLeftPadding(
+          child: ScrollableSectionLoading(),
+        ),
     };
   }
 }
@@ -52,7 +52,7 @@ class _BuildingsList extends ConsumerWidget {
 class _DataListBuildingsTiles extends ConsumerWidget {
   const _DataListBuildingsTiles(this.buildings);
 
-  final List<BuildingModel> buildings;
+  final IList<BuildingModel> buildings;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/home_view/widgets/departments_section/departments_section.dart
+++ b/lib/features/home_view/widgets/departments_section/departments_section.dart
@@ -1,8 +1,8 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../../utils/context_extensions.dart";
-import "../../../../utils/where_non_null_iterable.dart";
 import "../../../../widgets/my_error_widget.dart";
 import "../../../../widgets/subsection_header.dart";
 import "../../../departments_view/repository/departments_repository.dart";
@@ -26,13 +26,13 @@ class DepartmentsSection extends ConsumerWidget {
         ),
         SmallHorizontalPadding(
           child: switch (state) {
-            AsyncLoading() => const MediumLeftPadding(
-                child: ScrollableSectionLoading(),
-              ),
             AsyncError(:final error) => MyErrorWidget(error),
-            AsyncValue(:final value) => SizedBox(
+            AsyncValue(:final IList<Department> value) => SizedBox(
                 height: 120,
-                child: _DepartmentsDataList(value.whereNonNull.toList()),
+                child: _DepartmentsDataList(value),
+              ),
+            _ => const MediumLeftPadding(
+                child: ScrollableSectionLoading(),
               ),
           },
         ),
@@ -44,7 +44,7 @@ class DepartmentsSection extends ConsumerWidget {
 class _DepartmentsDataList extends ConsumerWidget {
   const _DepartmentsDataList(this.departments);
 
-  final List<Department> departments;
+  final IList<Department> departments;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/home_view/widgets/news_section.dart
+++ b/lib/features/home_view/widgets/news_section.dart
@@ -24,6 +24,7 @@ class NewsSection extends ConsumerWidget {
         children: [
           SubsectionHeader(
             title: context.localize.guide,
+            actionTitle: context.localize.list,
             onClick: ref.navigateGuide,
           ),
           const _NewsList(),

--- a/lib/features/home_view/widgets/news_section.dart
+++ b/lib/features/home_view/widgets/news_section.dart
@@ -6,7 +6,6 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../config/ui_config.dart";
 import "../../../utils/context_extensions.dart";
-import "../../../utils/where_non_null_iterable.dart";
 import "../../../widgets/big_preview_card.dart";
 import "../../../widgets/my_error_widget.dart";
 import "../../../widgets/subsection_header.dart";
@@ -39,7 +38,19 @@ class _NewsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(guideRepositoryProvider);
     return switch (state) {
-      AsyncLoading() => const Padding(
+      AsyncError(:final error) => MyErrorWidget(error),
+      AsyncValue(:final IList<GuidePost> value) => Padding(
+          padding: const EdgeInsets.only(
+            left: HomeViewConfig.paddingSmall,
+            right: HomeViewConfig.paddingSmall,
+            top: HomeViewConfig.paddingMedium,
+          ),
+          child: SizedBox(
+            height: BigPreviewCardConfig.cardHeight,
+            child: _NewsDataList(value),
+          ),
+        ),
+      _ => const Padding(
           padding: EdgeInsets.only(
             left: HomeViewConfig.paddingMedium,
             top: HomeViewConfig.paddingMedium *
@@ -51,18 +62,6 @@ class _NewsList extends ConsumerWidget {
             child: BigScrollableSectionLoading(),
           ),
         ),
-      AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => Padding(
-          padding: const EdgeInsets.only(
-            left: HomeViewConfig.paddingSmall,
-            right: HomeViewConfig.paddingSmall,
-            top: HomeViewConfig.paddingMedium,
-          ),
-          child: SizedBox(
-            height: BigPreviewCardConfig.cardHeight,
-            child: _NewsDataList(value.whereNonNull.toIList()),
-          ),
-        )
     };
   }
 }

--- a/lib/features/home_view/widgets/parkings_section.dart
+++ b/lib/features/home_view/widgets/parkings_section.dart
@@ -1,10 +1,10 @@
 import "dart:async";
 
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../utils/context_extensions.dart";
-import "../../../utils/where_non_null_iterable.dart";
 import "../../../widgets/my_error_widget.dart";
 import "../../../widgets/subsection_header.dart";
 import "../../navigator/utils/navigation_commands.dart";
@@ -38,16 +38,16 @@ class _ParkingsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(parkingsRepositoryProvider);
     return switch (state) {
-      AsyncLoading() => const MediumLeftPadding(
-          child: ScrollableSectionLoading(),
-        ),
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => SmallHorizontalPadding(
+      AsyncValue(:final IList<Parking> value) => SmallHorizontalPadding(
           child: SizedBox(
             height: 120,
-            child: _DataListParkingsTiles(value.whereNonNull.toList()),
+            child: _DataListParkingsTiles(value),
           ),
-        )
+        ),
+      _ => const MediumLeftPadding(
+          child: ScrollableSectionLoading(),
+        ),
     };
   }
 }
@@ -55,7 +55,7 @@ class _ParkingsList extends ConsumerWidget {
 class _DataListParkingsTiles extends ConsumerWidget {
   const _DataListParkingsTiles(this.parkings);
 
-  final List<Parking> parkings;
+  final IList<Parking> parkings;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/home_view/widgets/science_clubs_section.dart
+++ b/lib/features/home_view/widgets/science_clubs_section.dart
@@ -1,9 +1,9 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../config/ui_config.dart";
 import "../../../utils/context_extensions.dart";
-import "../../../utils/where_non_null_iterable.dart";
 import "../../../widgets/big_preview_card.dart";
 import "../../../widgets/my_error_widget.dart";
 import "../../../widgets/subsection_header.dart";
@@ -35,7 +35,19 @@ class _ScienceClubsList extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(scienceClubsRepositoryProvider);
     return switch (state) {
-      AsyncLoading() => const Padding(
+      AsyncError(:final error) => MyErrorWidget(error),
+      AsyncValue(:final IList<ScienceClub> value) => Container(
+          padding: const EdgeInsets.only(
+            left: HomeViewConfig.paddingSmall,
+            right: HomeViewConfig.paddingSmall,
+            top: HomeViewConfig.paddingMedium,
+          ),
+          child: SizedBox(
+            height: BigPreviewCardConfig.cardHeight,
+            child: _ScienceClubsDataList(value),
+          ),
+        ),
+      _ => const Padding(
           padding: EdgeInsets.only(
             left: HomeViewConfig.paddingMedium,
             top: HomeViewConfig.paddingMedium * 2,
@@ -46,20 +58,6 @@ class _ScienceClubsList extends ConsumerWidget {
             child: BigScrollableSectionLoading(),
           ),
         ),
-      AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => Container(
-          padding: const EdgeInsets.only(
-            left: HomeViewConfig.paddingSmall,
-            right: HomeViewConfig.paddingSmall,
-            top: HomeViewConfig.paddingMedium,
-          ),
-          child: SizedBox(
-            height: BigPreviewCardConfig.cardHeight,
-            child: _ScienceClubsDataList(
-              value.whereNonNull.toList(),
-            ),
-          ),
-        )
     };
   }
 }
@@ -67,7 +65,7 @@ class _ScienceClubsList extends ConsumerWidget {
 class _ScienceClubsDataList extends ConsumerWidget {
   const _ScienceClubsDataList(this.scienceClubs);
 
-  final List<ScienceClub> scienceClubs;
+  final IList<ScienceClub> scienceClubs;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/map_view/controllers/controllers_set.dart
+++ b/lib/features/map_view/controllers/controllers_set.dart
@@ -10,10 +10,10 @@ abstract class GoogleNavigable {
   LatLng get location;
 }
 
-typedef SourceRepositoryProv<T> = AutoDisposeFutureProvider<IList<T?>?>;
+typedef SourceRepositoryProv<T> = AutoDisposeFutureProvider<IList<T>>;
 
 typedef MapDataProv<T extends GoogleNavigable>
-    = AutoDisposeAsyncNotifierProvider<MapDataController<T>, IList<T?>?>;
+    = AutoDisposeAsyncNotifierProvider<MapDataController<T>, IList<T>>;
 
 typedef ActiveMarkerProv<T extends GoogleNavigable>
     = AutoDisposeNotifierProvider<ActiveMarkerController<T>, T?>;

--- a/lib/features/map_view/controllers/map_data_controller.dart
+++ b/lib/features/map_view/controllers/map_data_controller.dart
@@ -4,25 +4,24 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 import "controllers_set.dart";
 
 mixin MapDataController<T extends GoogleNavigable>
-    on AutoDisposeAsyncNotifier<IList<T?>?> {
+    on AutoDisposeAsyncNotifier<IList<T>> {
   String _textFieldFilterText = "";
   late final MapControllers<T> mapControllers;
 
   @override
-  FutureOr<IList<T?>?> build() async {
+  FutureOr<IList<T>> build() async {
     final itemSelected = ref.watch(mapControllers.activeMarker);
     if (itemSelected != null) {
       return [itemSelected].lock; // shows only selected building
     }
 
     final itemsData = await ref.watch(mapControllers.sourceRepo.future);
-    return itemsData?.where(_filterMethod).toIList();
+    return itemsData.where(_filterMethod).toIList();
   }
 
   bool filterMethod(T item, String filterStr);
 
-  bool _filterMethod(T? item) {
-    if (item == null) return false;
+  bool _filterMethod(T item) {
     final filter = _textFieldFilterText.toLowerCase();
     return filterMethod(item, filter);
   }

--- a/lib/features/map_view/widgets/map_widget.dart
+++ b/lib/features/map_view/widgets/map_widget.dart
@@ -24,7 +24,6 @@ class MapWidget<T extends GoogleNavigable> extends ConsumerWidget {
     final locationStatus = ref.watch(locationPermissionStatusProvider);
 
     return switch (locationStatus) {
-      AsyncLoading() => const SizedBox(),
       AsyncError(:final error) => MyErrorWidget(error),
       AsyncValue(:final value) => Consumer(
           builder: (BuildContext context, WidgetRef ref, Widget? child) {

--- a/lib/features/map_view/widgets/map_widget.dart
+++ b/lib/features/map_view/widgets/map_widget.dart
@@ -29,7 +29,7 @@ class MapWidget<T extends GoogleNavigable> extends ConsumerWidget {
           builder: (BuildContext context, WidgetRef ref, Widget? child) {
             final asyncItems = ref
                 .watch(context.mapSourceRepository<T>())
-                .value
+                .valueOrNull
                 .whereNonNull
                 .toList();
             return GoogleMap(

--- a/lib/features/navigator/utils/tab_bar_transition.dart
+++ b/lib/features/navigator/utils/tab_bar_transition.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
@@ -26,7 +27,7 @@ extension TabBarRouteTransitionBuilderX on Ref {
   TRoute? _getPreviousTab(String thisRouteName) {
     final navigator = read(navigationControllerProvider.notifier);
     final stack =
-        navigator.stack.where((element) => element.isTabView).toList();
+        navigator.stack.where((element) => element.isTabView).toIList();
     final didLastPop = navigator.didLastPop;
     final isThisLastRouteOnStack = stack.lastOrNull?.routeName == thisRouteName;
     return isThisLastRouteOnStack

--- a/lib/features/parking_chart/chart_elements/chart_line.dart
+++ b/lib/features/parking_chart/chart_elements/chart_line.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/material.dart";
 
@@ -6,7 +7,7 @@ import "../models/chart_point.dart";
 import "../utils/chart_utils.dart";
 
 class ChartLine extends LineChartBarData {
-  ChartLine(BuildContext context, List<ChartPoint> chartData)
+  ChartLine(BuildContext context, IList<ChartPoint> chartData)
       : super(
           isCurved: false,
           color: context.colorTheme.greyLight,
@@ -19,6 +20,6 @@ class ChartLine extends LineChartBarData {
             show: true,
             color: context.colorTheme.blueAzure.withOpacity(0.2),
           ),
-          spots: chartData,
+          spots: chartData.unlockLazy,
         );
 }

--- a/lib/features/parking_chart/models/hour_label.dart
+++ b/lib/features/parking_chart/models/hour_label.dart
@@ -9,7 +9,7 @@ extension type HourLabel(double numericalPoint) implements double {
   }
 
   static double _convertToNumericalRepresentation(String time) {
-    final List<String> parts = time.split(":");
+    final parts = time.split(":");
     if (parts.length < 2) return 0;
     final int hours = int.tryParse(parts[0]) ?? 0;
     final int minutes = int.tryParse(parts[1]) ?? 0;

--- a/lib/features/parking_chart/models/raw_chart_data.dart
+++ b/lib/features/parking_chart/models/raw_chart_data.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
 part "raw_chart_data.freezed.dart";
@@ -6,8 +7,8 @@ part "raw_chart_data.g.dart";
 @freezed
 class RawChartData with _$RawChartData {
   const factory RawChartData({
-    required List<String> data,
-    required List<String> labels,
+    required IList<String> data,
+    required IList<String> labels,
   }) = _RawChartData;
 
   factory RawChartData.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/parking_chart/parking_chart.dart
+++ b/lib/features/parking_chart/parking_chart.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
@@ -21,7 +22,27 @@ class ParkingChart extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final chartData = ref.watch(chartRepositoryProvider(parking));
     return switch (chartData) {
-      AsyncLoading() => Padding(
+      AsyncError(:final error) => Material(
+          borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
+          color: context.colorTheme.greyLight.withOpacity(0.8),
+          child: MyErrorWidget(error),
+        ),
+      AsyncValue(:final IList<ChartPoint> value) => value.isEmpty
+          ? Center(
+              child: Text(
+                context.localize.noChartData,
+                style: context.iParkingTheme.subtitleLight.withoutShadows,
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.only(
+                top: 20,
+                right: 25,
+                bottom: 10,
+              ),
+              child: ChartWidget(value, parking),
+            ),
+      _ => Padding(
           padding: const EdgeInsets.only(
             top: 18,
             left: 8,
@@ -33,33 +54,6 @@ class ParkingChart extends ConsumerWidget {
             width: double.infinity,
             color: context.colorTheme.greyPigeon.withOpacity(0.1),
           ),
-        ),
-      AsyncError(:final error) => Material(
-          borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
-          color: context.colorTheme.greyLight.withOpacity(0.8),
-          child: MyErrorWidget(error),
-        ),
-      AsyncValue(:final value) => Builder(
-          builder: (context) {
-            if (value == null) return const SizedBox.shrink();
-            final chartPoints = value.toChartPoints().toList();
-            if (chartPoints.isEmpty) {
-              return Center(
-                child: Text(
-                  context.localize.noChartData,
-                  style: context.iParkingTheme.subtitleLight.withoutShadows,
-                ),
-              );
-            }
-            return Padding(
-              padding: const EdgeInsets.only(
-                top: 20,
-                right: 25,
-                bottom: 10,
-              ),
-              child: ChartWidget(chartPoints, parking),
-            );
-          },
         ),
     };
   }

--- a/lib/features/parking_chart/repository/chart_repository.dart
+++ b/lib/features/parking_chart/repository/chart_repository.dart
@@ -1,20 +1,23 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../parkings_view/api_client/iparking_commands.dart";
 import "../../parkings_view/models/parking.dart";
+import "../models/chart_point.dart";
 import "../models/raw_chart_data.dart";
 
 part "chart_repository.g.dart";
 
 @riverpod
-Future<RawChartData> chartRepository(
+Future<IList<ChartPoint>> chartRepository(
   ChartRepositoryRef ref,
   Parking parking,
 ) async {
   final response = await ref.postIParkingCommand<Map<String, dynamic>>(
     FetchChartCommand(parking.id),
   );
-  return RawChartData.fromJson(
+  final rawData = RawChartData.fromJson(
     response.data?["slots"],
   );
+  return rawData.toChartPoints().toIList();
 }

--- a/lib/features/parking_chart/utils/chart_utils.dart
+++ b/lib/features/parking_chart/utils/chart_utils.dart
@@ -1,6 +1,7 @@
 import "dart:math";
 
 import "package:collection/collection.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fl_chart/fl_chart.dart";
 
 import "../../../config/ui_config.dart";
@@ -8,7 +9,7 @@ import "../../parkings_view/models/parking.dart";
 import "../models/chart_point.dart";
 import "../models/hour_label.dart";
 
-extension ChartUtilsX on List<ChartPoint> {
+extension ChartUtilsX on IList<ChartPoint> {
   double get minX => first.x;
   double get maxX => last.x;
 

--- a/lib/features/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parking_chart/widgets/chart_widget.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/material.dart";
 
@@ -14,7 +15,7 @@ import "reversed_label.dart";
 class ChartWidget extends StatelessWidget {
   const ChartWidget(this.chartData, this.parking, {super.key});
 
-  final List<ChartPoint> chartData;
+  final IList<ChartPoint> chartData;
   final Parking parking;
 
   @override

--- a/lib/features/parkings_view/api_client/iparking_commands.dart
+++ b/lib/features/parkings_view/api_client/iparking_commands.dart
@@ -27,6 +27,7 @@ extension IParkingCommandsX on AutoDisposeRef {
     try {
       return await watch(iParkingClientProvider).post("", data: command);
     } on DioException catch (_) {
+      await Future.delayed(const Duration(milliseconds: 300));
       throw ParkingsOfflineException();
     }
   }

--- a/lib/features/parkings_view/controllers.dart
+++ b/lib/features/parkings_view/controllers.dart
@@ -29,7 +29,7 @@ class ParkingsViewController extends _$ParkingsViewController
   }
   @override
   // ignore: unnecessary_overrides
-  FutureOr<IList<Parking?>?> build() async {
+  FutureOr<IList<Parking>> build() async {
     return super.build();
   }
 

--- a/lib/features/parkings_view/repository/parkings_repository.dart
+++ b/lib/features/parkings_view/repository/parkings_repository.dart
@@ -21,7 +21,7 @@ extension RefIntervalRefreshX on Ref {
 }
 
 @riverpod
-Future<IList<Parking>?> parkingsRepository(ParkingsRepositoryRef ref) async {
+Future<IList<Parking>> parkingsRepository(ParkingsRepositoryRef ref) async {
   ref.setRefresh(ParkingsConfig.parkingsRefreshInterval);
   final response = await ref.postIParkingCommand<Map<String, dynamic>>(
     FetchPlacesCommand(DateTime.now()),

--- a/lib/features/science_club_detail_view/science_club_detail_view.dart
+++ b/lib/features/science_club_detail_view/science_club_detail_view.dart
@@ -1,4 +1,5 @@
 import "package:auto_route/auto_route.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
@@ -42,14 +43,13 @@ class _SciClubDetailDataView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(scienceClubDetailsRepositoryProvider(id));
     return switch (state) {
-      AsyncLoading() => const _SciClubDetailViewLoading(),
       AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final value) => CustomScrollView(
+      AsyncValue(:final ScienceClubDetails value) => CustomScrollView(
           slivers: [
             SliverPersistentHeader(
               delegate: SliverHeaderSection(
-                logoDirectusImageUrl: value?.logo?.filename_disk,
-                backgroundImageUrl: value?.cover?.filename_disk,
+                logoDirectusImageUrl: value.logo?.filename_disk,
+                backgroundImageUrl: value.cover?.filename_disk,
               ),
             ),
             SliverList(
@@ -58,7 +58,7 @@ class _SciClubDetailDataView extends ConsumerWidget {
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
                   child: Text(
-                    value?.name ?? "",
+                    value.name,
                     style: context.textTheme.headline,
                     textAlign: TextAlign.center,
                     maxLines: 2,
@@ -66,31 +66,31 @@ class _SciClubDetailDataView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 12),
                 Text(
-                  value?.department?.name ?? "",
+                  value.department?.name ?? "",
                   style: context.textTheme.body,
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: DetailViewsConfig.spacerHeight),
                 ContactSection(
                   title: context.localize.contact,
-                  list: value?.links.whereNonNull
-                          .map(
-                            (a) => ContactIconsModel(
-                              text: a.name,
-                              url: a.link,
-                            ),
-                          )
-                          .toList() ??
-                      List.empty(),
+                  list: value.links.whereNonNull
+                      .map(
+                        (a) => ContactIconsModel(
+                          text: a.name,
+                          url: a.link,
+                        ),
+                      )
+                      .toIList(),
                 ),
                 const SizedBox(height: DetailViewsConfig.spacerHeight),
                 AboutUsSection(
-                  text: value?.description ?? "",
+                  text: value.description ?? "",
                 ),
               ]),
             ),
           ],
         ),
+      _ => const _SciClubDetailViewLoading(),
     };
   }
 }

--- a/lib/features/science_clubs_filters/filters_search_controller.dart
+++ b/lib/features/science_clubs_filters/filters_search_controller.dart
@@ -2,7 +2,6 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../utils/contains_lower_case.dart";
-import "../../utils/where_non_null_iterable.dart";
 import "../departments_view/repository/departments_repository.dart";
 import "model/sci_club_type.dart";
 import "repository/tags_repository.dart";
@@ -45,7 +44,7 @@ Future<IList<Department>> departmentFiltersFiltered(
 ) async {
   final query = ref.watch(searchFiltersControllerProvider);
   final depts = await ref.watch(departmentsRepositoryProvider.future);
-  return depts.whereNonNull
+  return depts
       .where(
         (x) =>
             x.name.containsLowerCase(query) ||
@@ -61,9 +60,7 @@ Future<IList<Tag>> tagFiltersFiltered(
 ) async {
   final query = ref.watch(searchFiltersControllerProvider);
   final tags = await ref.watch(tagsRepositoryProvider.future);
-  return tags.whereNonNull
-      .where((x) => x.name.containsLowerCase(query))
-      .toIList();
+  return tags.where((x) => x.name.containsLowerCase(query)).toIList();
 }
 
 @riverpod

--- a/lib/features/science_clubs_filters/repository/tags_repository.dart
+++ b/lib/features/science_clubs_filters/repository/tags_repository.dart
@@ -1,7 +1,9 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
 import "../../../config/ttl_config.dart";
+import "../../../utils/ilist_nonempty.dart";
 import "getTags.graphql.dart";
 
 part "tags_repository.g.dart";
@@ -9,10 +11,10 @@ part "tags_repository.g.dart";
 typedef Tag = Query$GetTags$Tags;
 
 @riverpod
-Future<List<Tag?>?> tagsRepository(TagsRepositoryRef ref) async {
+Future<IList<Tag>> tagsRepository(TagsRepositoryRef ref) async {
   final results = await ref.queryGraphql(
     WatchOptions$Query$GetTags(eagerlyFetchResults: true),
     TtlKey.tagsRepository,
   );
-  return results?.Tags;
+  return (results?.Tags).toIList();
 }

--- a/lib/features/science_clubs_view/controllers/science_clubs_view_controller.dart
+++ b/lib/features/science_clubs_view/controllers/science_clubs_view_controller.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../utils/contains_lower_case.dart";
@@ -18,7 +19,7 @@ class SearchScienceClubsController extends _$SearchScienceClubsController {
 }
 
 @riverpod
-Future<Iterable<ScienceClub?>?> _sciClubsFilteredByTextQuery(
+Future<Iterable<ScienceClub>> _sciClubsFilteredByTextQuery(
   _SciClubsFilteredByTextQueryRef ref,
 ) async {
   final originalList = await ref.watch(scienceClubsRepositoryProvider.future);
@@ -33,7 +34,7 @@ Future<Iterable<ScienceClub?>?> _sciClubsFilteredByTextQuery(
 }
 
 @riverpod
-Future<Iterable<ScienceClub?>?> scienceClubsListController(
+Future<IList<ScienceClub>> scienceClubsListController(
   ScienceClubsListControllerRef ref,
 ) async {
   final sciClubs =
@@ -41,7 +42,7 @@ Future<Iterable<ScienceClub?>?> scienceClubsListController(
           .whereNonNull;
 
   if (!ref.watch(areFiltersEnabledProvider)) {
-    return sciClubs;
+    return sciClubs.toIList();
   }
 
   final selectedTags =
@@ -72,5 +73,5 @@ Future<Iterable<ScienceClub?>?> scienceClubsListController(
               .any((tag) => selectedTags.contains(tag.Tags_id?.name)),
         );
 
-  return filteredByTags;
+  return filteredByTags.toIList();
 }

--- a/lib/features/science_clubs_view/repository/science_clubs_repository.dart
+++ b/lib/features/science_clubs_view/repository/science_clubs_repository.dart
@@ -4,6 +4,7 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../config/ttl_config.dart";
 import "../../../api_base/query_adapter.dart";
+import "../../../utils/ilist_nonempty.dart";
 import "getScienceClubs.graphql.dart";
 
 part "science_clubs_repository.g.dart";
@@ -18,7 +19,7 @@ Future<IList<ScienceClub>> scienceClubsRepository(
     Options$Query$GetScienceClubs(),
     TtlKey.scienceClubsRepository,
   );
-  return (results?.Scientific_Circles.sortBySourceTypes() ?? []).toIList();
+  return (results?.Scientific_Circles.sortBySourceTypes()).toIList();
 }
 
 extension IsSolvroX on ScienceClub {

--- a/lib/features/science_clubs_view/widgets/science_clubs_list.dart
+++ b/lib/features/science_clubs_view/widgets/science_clubs_list.dart
@@ -1,9 +1,9 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../config/ui_config.dart";
 import "../../../utils/context_extensions.dart";
-import "../../../utils/where_non_null_iterable.dart";
 import "../../../widgets/my_error_widget.dart";
 import "../../../widgets/search_not_found.dart";
 import "../../navigator/utils/navigation_commands.dart";
@@ -23,8 +23,8 @@ class ScienceClubsList extends ConsumerWidget {
         horizontal: ScienceClubsViewConfig.mediumPadding,
       ),
       child: switch (state) {
-        AsyncValue(:final Iterable<ScienceClub?> value) =>
-          _ScienceClubsListView(value.whereNonNull.toList()),
+        AsyncValue(:final IList<ScienceClub> value) =>
+          _ScienceClubsListView(value),
         AsyncError(:final error) => MyErrorWidget(error),
         _ => const ScienceClubsViewLoading(),
       },
@@ -35,7 +35,7 @@ class ScienceClubsList extends ConsumerWidget {
 class _ScienceClubsListView extends ConsumerWidget {
   const _ScienceClubsListView(this.filteredCircles);
 
-  final List<ScienceClub> filteredCircles;
+  final IList<ScienceClub> filteredCircles;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/utils/ilist_nonempty.dart
+++ b/lib/utils/ilist_nonempty.dart
@@ -1,0 +1,5 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+
+extension IListNonemptyX<T> on Iterable<T>? {
+  IList<T> toIList() => this?.toIList() ?? const IList.empty();
+}

--- a/lib/utils/last_or_null.dart
+++ b/lib/utils/last_or_null.dart
@@ -1,4 +1,6 @@
-extension LastOrNullX<T> on List<T> {
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+
+extension LastOrNullX<T> on IList<T> {
   T? get lastOrNull => isNotEmpty ? last : null;
 
   T? get preLastOrNull => length > 1 ? this[length - 2] : null;

--- a/lib/utils/launch_url_util.dart
+++ b/lib/utils/launch_url_util.dart
@@ -4,7 +4,6 @@ import "package:url_launcher/url_launcher.dart";
 
 import "../features/buildings_view/repository/buildings_repository.dart";
 import "../features/navigator/utils/navigation_commands.dart";
-import "../utils/where_non_null_iterable.dart";
 
 extension LaunchUrlUtilX on WidgetRef? {
   Future<bool> launch(String uriStr) async {
@@ -25,8 +24,7 @@ extension _LaunchTopwrRouteX on WidgetRef {
     if (uriStr.startsWith("topwr:buildings/")) {
       final id = uriStr.replaceFirst("topwr:buildings/", "");
       final buildings = await read(buildingsRepositoryProvider.future);
-      final building =
-          buildings.whereNonNull.firstWhereOrNull((i) => i.id == id);
+      final building = buildings.firstWhereOrNull((i) => i.id == id);
       if (building == null) return false;
       await navigateBuilding(building);
       return true;

--- a/lib/utils/where_non_null_iterable.dart
+++ b/lib/utils/where_non_null_iterable.dart
@@ -14,7 +14,8 @@ extension WhereNonNullX<T> on Iterable<T?> {
 
 extension WhereNonNullNullableX<T> on Iterable<T?>? {
   Iterable<T> get whereNonNull {
-    if (this == null) return [];
-    return this!.whereNonNull;
+    final strongThis = this;
+    if (strongThis == null) return [];
+    return strongThis.whereNonNull;
   }
 }

--- a/lib/widgets/detail_views/contact_section.dart
+++ b/lib/widgets/detail_views/contact_section.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/cupertino.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -10,12 +11,12 @@ import "contact_icon_widget.dart";
 class ContactSection extends StatelessWidget {
   const ContactSection({super.key, required this.list, required this.title});
 
-  final List<ContactIconsModel> list;
+  final IList<ContactIconsModel> list;
   final String title;
 
   @override
   Widget build(BuildContext context) {
-    list.sort((a, b) => a.order.compareTo(b.order));
+    final sorted = list.sort((a, b) => a.order.compareTo(b.order));
     return Container(
       padding: const EdgeInsets.only(top: 24, left: 24, right: 24, bottom: 8),
       color: context.colorTheme.greyLight,
@@ -24,7 +25,7 @@ class ContactSection extends StatelessWidget {
         children: [
           Text(title, style: context.textTheme.headline),
           const SizedBox(height: 16),
-          for (final item in list)
+          for (final item in sorted)
             Padding(
               padding: const EdgeInsets.only(bottom: 16),
               child: _ContactIcon(


### PR DESCRIPTION
So this is basically only refactoring.  This shouldn't change much.

1. this changes all the `Lists` to `ILIists` 
2. introduces `AsyncLoading` switch refactoring from #152 in all places
3. I also narrowed some types. Basically most of our repositories were introducing nullable types without a reason. Also this allowed me to remove some `whereNonNull`.


UPDATE: more or less fixes #178 (but there's one more issue with offline parkings I think - their "refresh" button on home view doesn't seem to work very well)