### PR TITLE
Feat/ add days to semester mode

### DIFF
--- a/lib/features/academic_calendar/utils/counter_digits.dart
+++ b/lib/features/academic_calendar/utils/counter_digits.dart
@@ -7,13 +7,15 @@ import "../repository/academic_calendar_repo.dart";
 
 enum Digit { first, second, third }
 
-extension DaysLeftStringConverter on AcademicCalendar {
+extension DaysLeftStringConverterX on AcademicCalendar {
   String get daysLeftFromNowString {
     final calendarData = this.AcademicCalendarData;
     final daysLeft = calendarData != null
         ? (calendarData.isHolidays()
             ? data?.semesterStartDate.daysLeftFromNow
-            : data?.examSessionLastDay.daysLeftFromNow)
+            : calendarData.isExamSession()
+                ? data?.examSessionLastDay.daysLeftFromNow
+                : data?.examSessionStartDate.daysLeftFromNow)
         : null;
 
     return max(_default, daysLeft ?? _default)
@@ -22,7 +24,7 @@ extension DaysLeftStringConverter on AcademicCalendar {
   }
 }
 
-extension GetDigitExtension on String {
+extension GetDigitX on String {
   String getDigit(Digit digit) =>
       length > digit.index ? this[digit.index] : _default.toString();
 }

--- a/lib/features/academic_calendar/utils/counter_digits.dart
+++ b/lib/features/academic_calendar/utils/counter_digits.dart
@@ -2,18 +2,24 @@ import "dart:math";
 
 import "../../../config/ui_config.dart";
 import "../../../utils/datetime_utils.dart";
+import "../model/academic_calendar_extensions.dart";
 import "../repository/academic_calendar_repo.dart";
 
 enum Digit { first, second, third }
 
 extension DaysLeftStringConverter on AcademicCalendar {
-  String get daysLeftFromNowString => max(
-        _default,
-        data?.examSessionStartDate.daysLeftFromNow ?? _default,
-      ).toString().padLeft(
-            Digit.values.length,
-            _default.toString(),
-          );
+  String get daysLeftFromNowString {
+    final calendarData = this.AcademicCalendarData;
+    final daysLeft = calendarData != null
+        ? (calendarData.isHolidays()
+            ? data?.semesterStartDate.daysLeftFromNow
+            : data?.examSessionLastDay.daysLeftFromNow)
+        : null;
+
+    return max(_default, daysLeft ?? _default)
+        .toString()
+        .padLeft(Digit.values.length, _default.toString());
+  }
 }
 
 extension GetDigitExtension on String {

--- a/lib/features/academic_calendar/utils/localize_academic_day.dart
+++ b/lib/features/academic_calendar/utils/localize_academic_day.dart
@@ -4,7 +4,7 @@ import "../../../utils/context_extensions.dart";
 import "../model/academic_day.dart";
 import "../model/weekday_enum.dart";
 
-extension LocalizeAcademicDay on AcademicDay {
+extension LocalizeAcademicDayX on AcademicDay {
   String localize(BuildContext context) {
     if (isHolidays) return weekday.localizeHoliday(context);
     if (isExamSession) return weekday.localizeExamSession(context);
@@ -14,7 +14,7 @@ extension LocalizeAcademicDay on AcademicDay {
   }
 }
 
-extension LocalizeWeekDay on WeekdayEnum {
+extension LocalizeWeekDayX on WeekdayEnum {
   String localizeEven(BuildContext context) {
     return switch (this) {
       WeekdayEnum.mon => context.localize.even_monday,

--- a/lib/features/academic_calendar/utils/localize_counter_message.dart
+++ b/lib/features/academic_calendar/utils/localize_counter_message.dart
@@ -1,0 +1,13 @@
+import "package:flutter/cupertino.dart";
+
+import "../../../utils/context_extensions.dart";
+import "../model/academic_calendar_extensions.dart";
+import "../repository/academic_calendar_repo.dart";
+
+extension LocalizeCounterMessageExtension on AcademicCalendar {
+  String localizeDaysCounterMessage(BuildContext context) {
+    if (this.AcademicCalendarData!.isHolidays()) return context.localize.until_the_end_of_the_semester_break;
+    if (this.AcademicCalendarData!.isExamSession()) return context.localize.until_the_session_ends;
+    return context.localize.days;
+  }
+}

--- a/lib/features/academic_calendar/utils/localize_counter_message.dart
+++ b/lib/features/academic_calendar/utils/localize_counter_message.dart
@@ -4,14 +4,16 @@ import "../../../utils/context_extensions.dart";
 import "../model/academic_calendar_extensions.dart";
 import "../repository/academic_calendar_repo.dart";
 
-extension LocalizeCounterMessageExtension on AcademicCalendar {
+extension LocalizeCounterMessageX on AcademicCalendar {
   String localizeDaysCounterMessage(BuildContext context) {
-    if (this.AcademicCalendarData!.isHolidays()) {
-      return context.localize.until_the_end_of_the_semester_break;
+    final calendarData = this.AcademicCalendarData;
+    if (calendarData != null) {
+      if (calendarData.isHolidays()) {
+        return context.localize.until_the_end_of_the_semester_break;
+      } else if (calendarData.isExamSession()) {
+        return context.localize.until_the_session_ends;
+      }
     }
-    if (this.AcademicCalendarData!.isExamSession()) {
-      return context.localize.until_the_session_ends;
-    }
-    return context.localize.days;
+    return context.localize.to_start_session;
   }
 }

--- a/lib/features/academic_calendar/utils/localize_counter_message.dart
+++ b/lib/features/academic_calendar/utils/localize_counter_message.dart
@@ -6,8 +6,10 @@ import "../repository/academic_calendar_repo.dart";
 
 extension LocalizeCounterMessageExtension on AcademicCalendar {
   String localizeDaysCounterMessage(BuildContext context) {
-    if (this.AcademicCalendarData!.isHolidays()) return context.localize.until_the_end_of_the_semester_break;
-    if (this.AcademicCalendarData!.isExamSession()) return context.localize.until_the_session_ends;
+    if (this.AcademicCalendarData!.isHolidays())
+      return context.localize.until_the_end_of_the_semester_break;
+    if (this.AcademicCalendarData!.isExamSession())
+      return context.localize.until_the_session_ends;
     return context.localize.days;
   }
 }

--- a/lib/features/academic_calendar/utils/localize_counter_message.dart
+++ b/lib/features/academic_calendar/utils/localize_counter_message.dart
@@ -6,10 +6,12 @@ import "../repository/academic_calendar_repo.dart";
 
 extension LocalizeCounterMessageExtension on AcademicCalendar {
   String localizeDaysCounterMessage(BuildContext context) {
-    if (this.AcademicCalendarData!.isHolidays())
+    if (this.AcademicCalendarData!.isHolidays()) {
       return context.localize.until_the_end_of_the_semester_break;
-    if (this.AcademicCalendarData!.isExamSession())
+    }
+    if (this.AcademicCalendarData!.isExamSession()) {
       return context.localize.until_the_session_ends;
+    }
     return context.localize.days;
   }
 }

--- a/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
+++ b/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
@@ -3,11 +3,14 @@ import "package:flutter/material.dart";
 import "../../../../theme/app_theme.dart";
 import "../../../../utils/context_extensions.dart";
 import "../../repository/academic_calendar_repo.dart";
+import "../../utils/localize_counter_message.dart";
 import "digits_widgets.dart";
 
 class ExamSessionCountdown extends StatelessWidget {
   const ExamSessionCountdown(this.academicCalendar, {super.key});
+
   final AcademicCalendar academicCalendar;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -32,19 +35,25 @@ class ExamSessionCountdown extends StatelessWidget {
               padding: const EdgeInsets.all(16),
               child: DigitsRow(academicCalendar),
             ),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  context.localize.days,
-                  style: context.textTheme.headlineWhite,
-                ),
-                Text(
-                  context.localize.to_start_session,
-                  style: context.textTheme.bodyWhite,
-                ),
-              ],
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.localize.days,
+                    style: context.textTheme.headlineWhite,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: Text(
+                      academicCalendar.localizeDaysCounterMessage(context),
+                      style: context.textTheme.bodyWhite,
+                      textScaler: const TextScaler.linear(0.97),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -94,5 +94,8 @@
   "bug_report_subtitle":"Wyślij zgłoszenie bezpośrednio do twórców aplikacji.",
   "new_feature": "Nowa funckcjonalność",
   "bug" : "Błąd",
-  "praise" : "Pochwała"
+  "praise" : "Pochwała",
+  "until_the_end_of_the_semester_break": "do końca przerwy międzysemestralnej",
+  "until_the_session_ends": "do zakończenia sesji"
+
 }


### PR DESCRIPTION
## About

- During the holiday season, the counter counts down the days until the start of the next semester.
- During the exam session, the counter tracks the days remaining until the session ends.
- After the semester starts and before the session begins, the counter displays the days between these two events.
- It's crucial to regularly update the dates in the API.

<img src="https://github.com/user-attachments/assets/30f8b3f1-ed3f-4537-b555-fc2e039aaad3" width="50%">