### PR TITLE
#198 - deep links support - android setup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:name=".MainActivity"
             android:enableOnBackInvokedCallback="true"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
@@ -26,10 +26,25 @@
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme"
             />
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="true" />
+
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="topwr.solvro.pl" />
+            </intent-filter>
+
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
@simon-the-shark

Commit looks extremely simple but trust me, it took me 3h to set it up accordingly XD. Since I'm not that rich yet, I haven't got a Mac machine. Could you please set up iOS config regarding deeplinks? I belive proper docs could be found [here](https://docs.flutter.dev/cookbook/navigation/set-up-universal-links#adjust-ios-build-settings).

Things to know before:

default domain is: topwr.solvro.pl eg.: topwr.solvro.pl/guide topwr.solvro.pl/departments/1 etc.

uri's end must be same as path set up in navigation. In our project paths are meaningful and self-descriptive so I didn't set additional config as described [here](https://pub.dev/packages/auto_route#deep-linking). If the uri's end is other we must perform additional coding but I believe default paths are enough (at least for now).

Android solution's been tested on my real device (Xiaomi Mi9 Se) and works fine. Please, test it on your own as well.

What's worth mentioning, when link's opened within eg. Messenger, app web view opens (not our app), same happens with deep links from other apps like OLX. It seems that we can't do much about it.