### PR TITLE
#142 - fix RenderFlex overflow error - fix

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -53,6 +53,7 @@ abstract class HomeViewConfig {
 abstract class BigPreviewCardConfig {
   static const cardHeight = 360.0;
   static const cardWidth = 240.0;
+  static const defaultCrossAxisForcedSize = 220.0;
 }
 
 abstract class SearchBoxConfig {

--- a/lib/features/department_detail_view/widgets/view_loading.dart
+++ b/lib/features/department_detail_view/widgets/view_loading.dart
@@ -20,7 +20,9 @@ class DepartmentDetailViewLoading extends StatelessWidget {
           SizedBox(height: DetailViewsConfig.spacerHeight),
           ContactSectionLoading(),
           SizedBox(height: DetailViewsConfig.spacerHeight),
-          BigScrollableSectionLoading(),
+          BigScrollableSectionLoading(
+            crossAxisForcedSize: 400,
+          ),
         ],
       ),
     );

--- a/lib/features/home_view/widgets/loading_widgets/big_scrollable_section_loading.dart
+++ b/lib/features/home_view/widgets/loading_widgets/big_scrollable_section_loading.dart
@@ -8,12 +8,15 @@ import "../paddings.dart";
 class BigScrollableSectionLoading extends StatelessWidget {
   const BigScrollableSectionLoading({
     super.key,
+    this.crossAxisForcedSize = BigPreviewCardConfig.defaultCrossAxisForcedSize,
   });
+
+  final double crossAxisForcedSize;
 
   @override
   Widget build(BuildContext context) {
     return ScrollableLoaderBuilder(
-      crossAxisForcedSize: 220,
+      crossAxisForcedSize: crossAxisForcedSize,
       mainAxisItemSize: BigPreviewCardConfig.cardWidth,
       scrollDirection: Axis.horizontal,
       itemBuilder: (context, index) {


### PR DESCRIPTION
- in department's details screen default value of `crossAxisForcedSize `was too low.  I decided to parameterize mentioned variable with default value as before.
- now at the department's screen loading section value of 400 is passed. 
- tested on Pixel 8 Pro 