### PR TITLE
#221 - add cache support for map tiles

### DIFF
--- a/lib/config/map_view_config.dart
+++ b/lib/config/map_view_config.dart
@@ -51,6 +51,12 @@ abstract class OpenStreetMapConfig {
       Platform.isIOS ? "com.solvro.ToPwr" : "com.solvro.topwr";
 }
 
+abstract class MapCacheConfig {
+  // in days
+  static const cacheDuration = 30;
+  static const cacheBoxName = "HiveMapCacheStore";
+}
+
 abstract class BuildingSearchConfig {
   static const buildingCodeSeperator = "-";
 }

--- a/lib/features/map_view/widgets/map_widget.dart
+++ b/lib/features/map_view/widgets/map_widget.dart
@@ -1,6 +1,7 @@
+import "package:dio_cache_interceptor_hive_store/dio_cache_interceptor_hive_store.dart";
 import "package:flutter/material.dart";
 import "package:flutter_map/flutter_map.dart";
-import "package:flutter_map_cancellable_tile_provider/flutter_map_cancellable_tile_provider.dart";
+import "package:flutter_map_cache/flutter_map_cache.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../config/map_view_config.dart";
@@ -38,7 +39,13 @@ class MapWidget<T extends GoogleNavigable> extends ConsumerWidget {
         TileLayer(
           urlTemplate: OpenStreetMapConfig.tileUrl,
           userAgentPackageName: OpenStreetMapConfig.userAgent,
-          tileProvider: CancellableNetworkTileProvider(),
+          tileProvider: CachedTileProvider(
+            maxStale: const Duration(days: MapCacheConfig.cacheDuration),
+            store: HiveCacheStore(
+              null,
+              hiveBoxName: MapCacheConfig.cacheBoxName,
+            ),
+          ),
         ),
         MarkersConsumerLayer<T>(),
         const MyLocationLayer(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,12 +73,14 @@ dependencies:
   flutter_map_cancellable_tile_provider: ^3.0.2
   flutter_map_location_marker: ^9.1.1
   flutter_map_compass: ^1.0.3
+  flutter_map_cache: ^1.3.0
   hooks_riverpod: ^2.5.2
   firebase_crashlytics: ^4.1.2
   firebase_analytics: ^11.3.2
   firebase_core: ^3.5.0
   firebase_performance: ^0.10.0+7
   firebase_messaging: ^15.1.2
+  dio_cache_interceptor_hive_store: ^3.2.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I've added cachce support for map tiles. 

- I've been wondering if flushing map's cache should be possible from an API. I've decided not to implement that feature for now (maps don't change that often I guess,at least ones that we use).  If you think differently, I can change it of course
- in the Hive implementation you can see `null` passed in place of directory path. Documentation says that if we use Hive already in the project, there's no need to provide it again. I guess that's correct in our situation. 
- do you know any ways to change if caching actually works (some logging or sth)? 