### PR TITLE
#230 - replace decimal numbers with integers at parking's page & make sure that free slots are always >= 0

### DIFF
--- a/lib/features/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parking_chart/widgets/chart_widget.dart
@@ -2,6 +2,7 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/material.dart";
 
+import "../../../theme/app_theme.dart";
 import "../../parkings_view/models/parking.dart";
 import "../chart_elements/chart_border.dart";
 import "../chart_elements/chart_grid.dart";
@@ -39,6 +40,22 @@ class ChartWidget extends StatelessWidget {
               maxX: chartData.maxX,
               maxY: chartData.maxY(parking),
               minY: 0,
+              lineTouchData:
+                  LineTouchData(touchTooltipData: LineTouchTooltipData(
+                getTooltipItems: (touchedSpots) {
+                  return touchedSpots.map((touchedSpot) {
+                    final value =
+                        touchedSpot.y.toInt(); // Convert double to int
+                    return LineTooltipItem(
+                      value.toString(),
+                      TextStyle(
+                        color: context.colorTheme.whiteSoap,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    );
+                  }).toList();
+                },
+              ),),
             ),
           ),
         ),

--- a/lib/features/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parking_chart/widgets/chart_widget.dart
@@ -40,22 +40,23 @@ class ChartWidget extends StatelessWidget {
               maxX: chartData.maxX,
               maxY: chartData.maxY(parking),
               minY: 0,
-              lineTouchData:
-                  LineTouchData(touchTooltipData: LineTouchTooltipData(
-                getTooltipItems: (touchedSpots) {
-                  return touchedSpots.map((touchedSpot) {
-                    final value =
-                        touchedSpot.y.toInt(); // Convert double to int
-                    return LineTooltipItem(
-                      value.toString(),
-                      TextStyle(
-                        color: context.colorTheme.whiteSoap,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    );
-                  }).toList();
-                },
-              ),),
+              lineTouchData: LineTouchData(
+                touchTooltipData: LineTouchTooltipData(
+                  getTooltipItems: (touchedSpots) {
+                    return touchedSpots.map((touchedSpot) {
+                      final value =
+                          touchedSpot.y.toInt(); // Convert double to int
+                      return LineTooltipItem(
+                        value.toString(),
+                        TextStyle(
+                          color: context.colorTheme.whiteSoap,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      );
+                    }).toList();
+                  },
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/features/parkings_view/models/parking.dart
+++ b/lib/features/parkings_view/models/parking.dart
@@ -42,6 +42,8 @@ class Parking with _$Parking implements GoogleNavigable {
     return ParkingsConfig.rootUrl + photo.trim();
   }
 
+  String get parsedNumberOfPlaces => numberOfPlaces.startsWith("-") ? "0" : numberOfPlaces;
+
   double get latitude => double.tryParse(geoLat) ?? 0;
   double get longitude => double.tryParse(geoLan) ?? 0;
 

--- a/lib/features/parkings_view/models/parking.dart
+++ b/lib/features/parkings_view/models/parking.dart
@@ -42,7 +42,8 @@ class Parking with _$Parking implements GoogleNavigable {
     return ParkingsConfig.rootUrl + photo.trim();
   }
 
-  String get parsedNumberOfPlaces => numberOfPlaces.startsWith("-") ? "0" : numberOfPlaces;
+  String get parsedNumberOfPlaces =>
+      numberOfPlaces.startsWith("-") ? "0" : numberOfPlaces;
 
   double get latitude => double.tryParse(geoLat) ?? 0;
   double get longitude => double.tryParse(geoLan) ?? 0;

--- a/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
+++ b/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
@@ -137,7 +137,7 @@ class _RightColumn extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Text(
-              parking.numberOfPlaces,
+              parking.parsedNumberOfPlaces,
               style: isActive
                   ? context.iParkingTheme.title.withoutShadows
                   : context.iParkingTheme.title,


### PR DESCRIPTION
- It would be perfect to notify the person reporting the error for morale support.  
  <img src="https://github.com/user-attachments/assets/74bef9a9-69c6-4748-9771-b962a3208d18" alt="Image 1" width="400"/>

- I’ve also implemented a mechanism that ensures that the number of available spaces is always equal to or greater than 0 (never negative, as happened on 24/09/2024).  
  <img src="https://github.com/user-attachments/assets/58369226-e31e-42dc-9bd2-cbf1b6925222" alt="Image 2" width="400"/>





