### PR TITLE
fix: change bottom padding on home view

### DIFF
--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -32,7 +32,7 @@ class HomeView extends StatelessWidget {
       appBar: LogoAppBar(context),
       body: KeepAliveHomeViewProviders(
         child: ListView.separated(
-          padding: const EdgeInsets.only(bottom: 48),
+          padding: const EdgeInsets.only(bottom: 24),
           itemBuilder: (context, index) => sections[index],
           separatorBuilder: (context, index) =>
               const SizedBox(height: HomeViewConfig.paddingMedium),


### PR DESCRIPTION
#240 
I changed bottom padding on home view. Now all tabs have the same -> 24px
some ss's:
![image](https://github.com/user-attachments/assets/ceec3550-4d31-42d8-a4f2-fb17710129c2)
![image](https://github.com/user-attachments/assets/31973b52-c4e8-40ec-9ed0-b84bf521e5f8)
![image](https://github.com/user-attachments/assets/1d90d7fd-4d73-4e32-88ea-802fb487e109)
