### PR TITLE
feat - #238 sort links on about us team

### DIFF
--- a/lib/config/contact_icons.dart
+++ b/lib/config/contact_icons.dart
@@ -14,7 +14,7 @@ abstract class ContactIconsConfig {
     "tiktok": Assets.svg.contactIcons.tiktok,
     "discord": Assets.svg.contactIcons.discord,
   };
-  static final iconsOrder = {
+  static final iconsOrderAtSciClubs = {
     "maps": 1,
     "tel": 2,
     "mailto:": 3,
@@ -27,6 +27,20 @@ abstract class ContactIconsConfig {
     "youtu": 11,
     "tiktok": 12,
   };
-  static const defaultIconOrder = 2;
+  static final iconsOrderAtAboutUs = {
+    "github": 1,
+    "linkedin": 2,
+    "facebook": 4,
+    "mailto:": 5,
+    "instagram": 6,
+    "https://x.com": 7,
+    "discord": 8,
+    "youtu": 9,
+    "tiktok": 10,
+    "maps": 11,
+    "tel": 12,
+  };
+  static const defaultIconOrderAtSciClubs = 2;
+  static const defaultIconOrderAtAboutUs = 3;
   static final defaultIcon = Assets.svg.contactIcons.web;
 }

--- a/lib/features/about_us_view/about_us_view.dart
+++ b/lib/features/about_us_view/about_us_view.dart
@@ -65,13 +65,13 @@ class _AboutUsView extends ConsumerWidget {
             ),
           ],
         ),
-      _ => const _AboustUsLoading(),
+      _ => const _AboutUsLoading(),
     };
   }
 }
 
-class _AboustUsLoading extends StatelessWidget {
-  const _AboustUsLoading();
+class _AboutUsLoading extends StatelessWidget {
+  const _AboutUsLoading();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/about_us_view/models/about_us_details.dart
+++ b/lib/features/about_us_view/models/about_us_details.dart
@@ -28,6 +28,7 @@ class AboutUsDetails {
         .map(
           (e) => ContactIconsModel(url: e.url),
         )
-        .toIList();
+        .toIList()
+        .sort((a, b) => a.order.compareTo(b.order));
   }
 }

--- a/lib/features/about_us_view/models/member_data.dart
+++ b/lib/features/about_us_view/models/member_data.dart
@@ -20,7 +20,7 @@ class MemberData {
 
   static IList<ContactIconsModel> _determineLinksIcons(IList<String> urls) {
     return urls
-        .map((url) => ContactIconsModel(url: url, isSciClub: false))
+        .map((url) => ContactIconsModel(url: url, isTeamMember: true))
         .toIList()
         .sort((a, b) => a.order.compareTo(b.order));
   }

--- a/lib/features/about_us_view/models/member_data.dart
+++ b/lib/features/about_us_view/models/member_data.dart
@@ -19,7 +19,10 @@ class MemberData {
   }) : links = _determineLinksIcons(socialLinks);
 
   static IList<ContactIconsModel> _determineLinksIcons(IList<String> urls) {
-    return urls.map((url) => ContactIconsModel(url: url)).toIList();
+    return urls
+        .map((url) => ContactIconsModel(url: url, isSciClub: false))
+        .toIList()
+        .sort((a, b) => a.order.compareTo(b.order));
   }
 
   @override

--- a/lib/utils/determine_contact_icon.dart
+++ b/lib/utils/determine_contact_icon.dart
@@ -9,12 +9,16 @@ class ContactIconsModel {
   final String? text;
   final String? url;
   final int order;
+  final bool isSciClub;
 
   ContactIconsModel({
     String? text,
     this.url,
+    this.isSciClub = true,
   })  : icon = url.determineIcon(),
-        order = url.determineIconOrder(),
+        order = isSciClub
+            ? url.determineIconOrderForSciClubs()
+            : url.determineIconOrderForAboutUs(),
         text = text ?? url;
 }
 
@@ -30,14 +34,25 @@ extension IconDeterminerX on String? {
         : ContactIconsConfig.defaultIcon;
   }
 
-  int determineIconOrder() {
+  int determineIconOrderForSciClubs() {
     return this != null
-        ? ContactIconsConfig.iconsOrder.entries
+        ? ContactIconsConfig.iconsOrderAtSciClubs.entries
                 .firstWhereOrNull(
                   (e) => this!.contains(e.key),
                 )
                 ?.value ??
-            ContactIconsConfig.defaultIconOrder
-        : ContactIconsConfig.defaultIconOrder;
+            ContactIconsConfig.defaultIconOrderAtSciClubs
+        : ContactIconsConfig.defaultIconOrderAtSciClubs;
+  }
+
+  int determineIconOrderForAboutUs() {
+    return this != null
+        ? ContactIconsConfig.iconsOrderAtAboutUs.entries
+                .firstWhereOrNull(
+                  (e) => this!.contains(e.key),
+                )
+                ?.value ??
+            ContactIconsConfig.defaultIconOrderAtAboutUs
+        : ContactIconsConfig.defaultIconOrderAtAboutUs;
   }
 }

--- a/lib/utils/determine_contact_icon.dart
+++ b/lib/utils/determine_contact_icon.dart
@@ -9,14 +9,14 @@ class ContactIconsModel {
   final String? text;
   final String? url;
   final int order;
-  final bool isSciClub;
+  final bool isTeamMember;
 
   ContactIconsModel({
     String? text,
     this.url,
-    this.isSciClub = true,
+    this.isTeamMember = false,
   })  : icon = url.determineIcon(),
-        order = isSciClub
+        order = !isTeamMember
             ? url.determineIconOrderForSciClubs()
             : url.determineIconOrderForAboutUs(),
         text = text ?? url;


### PR DESCRIPTION
#238 
- separate sorting is now included for sci clubs and about us team
- maybe it's good idea to make sorting not local but on backend? @Rei-x 