### PR TITLE
Feat/ add verified checkmark to science clubs in all other places

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -114,6 +114,7 @@ abstract class ScienceClubsViewConfig {
 
 abstract class ScienceClubCardConfig {
   static const trailingPadding = 2.0;
+  static const source = "manual_entry";
 }
 
 abstract class ParkingsConfig {

--- a/lib/features/department_detail_view/widgets/science_clubs_section.dart
+++ b/lib/features/department_detail_view/widgets/science_clubs_section.dart
@@ -83,6 +83,7 @@ class _ScienceClubsList extends ConsumerWidget {
                 ? sciClub.cover?.filename_disk
                 : sciClub.logo?.filename_disk,
             onClick: () async => ref.navigateSciClubsDetail(sciClub.id),
+            showBadge: sciClub.source == ScienceClubCardConfig.source,
           ),
         );
       },

--- a/lib/features/home_view/widgets/science_clubs_section.dart
+++ b/lib/features/home_view/widgets/science_clubs_section.dart
@@ -105,6 +105,7 @@ class _BuildScienceClubCard extends StatelessWidget {
           ? sciClub.cover?.filename_disk
           : sciClub.logo?.filename_disk,
       onClick: () async => ref.navigateSciClubsDetail(sciClub.id),
+      showBadge: sciClub.source == ScienceClubCardConfig.source,
     );
   }
 }

--- a/lib/features/science_clubs_view/widgets/science_club_card.dart
+++ b/lib/features/science_clubs_view/widgets/science_club_card.dart
@@ -21,7 +21,7 @@ class ScienceClubCard extends StatelessWidget {
           ?.map((tag) => "#${tag?.Tags_id?.name}")
           .toList()
           .join(", "),
-      showBadge: sciClub.source == "manual_entry",
+      showBadge: sciClub.source == ScienceClubCardConfig.source,
       activeShadows: null,
       trailing: Padding(
         padding: const EdgeInsets.only(

--- a/lib/widgets/big_preview_card.dart
+++ b/lib/widgets/big_preview_card.dart
@@ -8,15 +8,15 @@ import "dual_text_max_lines.dart";
 import "optimized_directus_image.dart";
 
 class BigPreviewCard extends StatelessWidget {
-  const BigPreviewCard({
-    super.key,
-    required this.title,
-    required this.shortDescription,
-    required this.directusUrl,
-    this.date,
-    required this.onClick,
-    this.boxFit = BoxFit.scaleDown,
-  });
+  const BigPreviewCard(
+      {super.key,
+      required this.title,
+      required this.shortDescription,
+      required this.directusUrl,
+      this.date,
+      required this.onClick,
+      this.boxFit = BoxFit.scaleDown,
+      this.showBadge = false,});
 
   final String title;
   final String shortDescription;
@@ -24,6 +24,7 @@ class BigPreviewCard extends StatelessWidget {
   final DateTime? date;
   final VoidCallback? onClick;
   final BoxFit boxFit;
+  final bool showBadge;
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +77,7 @@ class BigPreviewCard extends StatelessWidget {
                     subtitleStyle: context.textTheme.body,
                     spacing: 7,
                     maxTotalLines: 8,
+                    showBadge: showBadge,
                   ),
                   const Spacer(),
                   MaterialButton(

--- a/lib/widgets/big_preview_card.dart
+++ b/lib/widgets/big_preview_card.dart
@@ -8,15 +8,16 @@ import "dual_text_max_lines.dart";
 import "optimized_directus_image.dart";
 
 class BigPreviewCard extends StatelessWidget {
-  const BigPreviewCard(
-      {super.key,
-      required this.title,
-      required this.shortDescription,
-      required this.directusUrl,
-      this.date,
-      required this.onClick,
-      this.boxFit = BoxFit.scaleDown,
-      this.showBadge = false,});
+  const BigPreviewCard({
+    super.key,
+    required this.title,
+    required this.shortDescription,
+    required this.directusUrl,
+    this.date,
+    required this.onClick,
+    this.boxFit = BoxFit.scaleDown,
+    this.showBadge = false,
+  });
 
   final String title;
   final String shortDescription;

--- a/lib/widgets/dual_text_max_lines.dart
+++ b/lib/widgets/dual_text_max_lines.dart
@@ -32,16 +32,11 @@ class DualTextSpan extends TextSpan {
                       ),
                     ),
                   ),
-                if (subtitle != null)
-                  TextSpan(
-                    text: "\n",
-                    style: TextStyle(fontSize: spacing, height: 1),
-                  ),
               ],
             ),
             if (subtitle != null)
               TextSpan(
-                text: "\n", // padding/spacing workaround
+                text: "\n\n", // padding/spacing workaround
                 style: TextStyle(fontSize: spacing, height: 1),
               ),
             if (subtitle != null)

--- a/lib/widgets/dual_text_max_lines.dart
+++ b/lib/widgets/dual_text_max_lines.dart
@@ -1,18 +1,40 @@
 import "package:flutter/material.dart";
 
+import "../theme/colors.dart";
+
 class DualTextSpan extends TextSpan {
   DualTextSpan(
     String title,
     TextStyle? titleStyle,
     String? subtitle,
     TextStyle? subtitleStyle,
-    double spacing,
-  ) : super(
+    double spacing, {
+    bool showBadge = false,
+  }) : super(
           children: [
-            TextSpan(
-              text: subtitle == null ? title : "$title\n",
-              style: titleStyle,
-            ),
+            TextSpan(text: title, style: titleStyle, children: [
+              if (showBadge)
+                const WidgetSpan(
+                  baseline: TextBaseline.ideographic,
+                  alignment: PlaceholderAlignment.middle,
+                  child: SizedBox.square(
+                    dimension: 16,
+                    child: Padding(
+                      padding: EdgeInsets.only(left: 4),
+                      child: Icon(
+                        Icons.verified_sharp,
+                        size: 12,
+                        color: ColorsConsts.orangePomegranade,
+                      ),
+                    ),
+                  ),
+                ),
+              if (subtitle != null)
+                TextSpan(
+                  text: "\n",
+                  style: TextStyle(fontSize: spacing, height: 1),
+                ),
+            ],),
             if (subtitle != null)
               TextSpan(
                 text: "\n", // padding/spacing workaround
@@ -35,6 +57,7 @@ class DualTextMaxLines extends StatelessWidget {
     this.titleStyle,
     this.subtitleStyle,
     this.spacing = 0,
+    this.showBadge = false,
     super.key,
   });
 
@@ -43,14 +66,22 @@ class DualTextMaxLines extends StatelessWidget {
   final String? subtitle;
   final TextStyle? subtitleStyle;
   final double spacing;
-
   final int maxTotalLines;
+  final bool showBadge;
+
   @override
   Widget build(BuildContext context) {
     return RichText(
       maxLines: maxTotalLines,
       overflow: TextOverflow.ellipsis,
-      text: DualTextSpan(title, titleStyle, subtitle, subtitleStyle, spacing),
+      text: DualTextSpan(
+        title,
+        titleStyle,
+        subtitle,
+        subtitleStyle,
+        spacing,
+        showBadge: showBadge,
+      ),
     );
   }
 }

--- a/lib/widgets/dual_text_max_lines.dart
+++ b/lib/widgets/dual_text_max_lines.dart
@@ -12,29 +12,33 @@ class DualTextSpan extends TextSpan {
     bool showBadge = false,
   }) : super(
           children: [
-            TextSpan(text: title, style: titleStyle, children: [
-              if (showBadge)
-                const WidgetSpan(
-                  baseline: TextBaseline.ideographic,
-                  alignment: PlaceholderAlignment.middle,
-                  child: SizedBox.square(
-                    dimension: 16,
-                    child: Padding(
-                      padding: EdgeInsets.only(left: 4),
-                      child: Icon(
-                        Icons.verified_sharp,
-                        size: 12,
-                        color: ColorsConsts.orangePomegranade,
+            TextSpan(
+              text: title,
+              style: titleStyle,
+              children: [
+                if (showBadge)
+                  const WidgetSpan(
+                    baseline: TextBaseline.ideographic,
+                    alignment: PlaceholderAlignment.middle,
+                    child: SizedBox.square(
+                      dimension: 16,
+                      child: Padding(
+                        padding: EdgeInsets.only(left: 4),
+                        child: Icon(
+                          Icons.verified_sharp,
+                          size: 12,
+                          color: ColorsConsts.orangePomegranade,
+                        ),
                       ),
                     ),
                   ),
-                ),
-              if (subtitle != null)
-                TextSpan(
-                  text: "\n",
-                  style: TextStyle(fontSize: spacing, height: 1),
-                ),
-            ],),
+                if (subtitle != null)
+                  TextSpan(
+                    text: "\n",
+                    style: TextStyle(fontSize: spacing, height: 1),
+                  ),
+              ],
+            ),
             if (subtitle != null)
               TextSpan(
                 text: "\n", // padding/spacing workaround


### PR DESCRIPTION
#263 

- Checkmarks are now displayed in every place that study circle tile's present.
- I've refactored logic responsible for determining if checkmarks should be displayed.
- Please check the visual effect and tell if you like it ;)
- I wonder if we should implement some kind of checkmark even in the study circle's details?

<img src="https://github.com/user-attachments/assets/c349c9e1-476a-4a58-93d3-81a82aa44a94" width="300" />
<img src="https://github.com/user-attachments/assets/13d57365-1b8b-4ebd-b08e-2347d859534d" width="300" />
