### PR TITLE
feat/add-shadows-to-trend-arrow

### DIFF
--- a/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
+++ b/lib/features/parkings_view/widgets/parking_wide_tile_card.dart
@@ -155,6 +155,7 @@ class _RightColumn extends StatelessWidget {
                   ? arrowColor(parking.trend, context)
                   : context.colorTheme.whiteSoap,
               size: 21,
+              shadows: iparkingShadows,
             ),
           ],
         ),


### PR DESCRIPTION
Now trend arrow has shadows like every component in ParkingWideTileCard