### PR TITLE
feature: add dates to guide

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -151,6 +151,7 @@ abstract class GuideDetailViewConfig {
   static const paddingMedium = 16.0;
   static const paddingLarge = 32.0;
   static const borderRadius = 8.0;
+  static const bottomPadding = 24.0;
 }
 
 abstract class GuideViewConfig {

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../config/ui_config.dart";
+import "../../theme/app_theme.dart";
 import "../../utils/context_extensions.dart";
 import "../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../widgets/loading_widgets/shimmer_loading.dart";
@@ -12,6 +13,7 @@ import "../../widgets/my_expansion_tile.dart";
 import "../../widgets/my_html_widget.dart";
 import "../../widgets/optimized_directus_image.dart";
 import "repository/guide_detail_view_repository.dart";
+import "utils/get_the_latest_date.dart";
 import "widgets/faq_expansion_tile.dart";
 
 @RoutePage()
@@ -74,6 +76,27 @@ class _GuideDetailDataView extends ConsumerWidget {
                   );
                 },
                 separatorBuilder: (context, index) => const SizedBox(height: 8),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.only(
+                bottom: GuideDetailViewConfig.bottomPadding,
+              ),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  children: [
+                    Text(
+                      "${context.localize.created_at} ${context.getTheLatesCreatedDateGuide(questions: value.questions) ?? context.localize.not_date_available}",
+                      style: context.textTheme.bodyGrey,
+                      textAlign: TextAlign.end,
+                    ),
+                    Text(
+                      "${context.localize.last_modified} ${context.getTheLatesUpdatedDateGuide(questions: value.questions) ?? context.localize.not_date_available}",
+                      style: context.textTheme.bodyGrey,
+                      textAlign: TextAlign.end,
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -86,12 +86,12 @@ class _GuideDetailDataView extends ConsumerWidget {
                 child: Column(
                   children: [
                     Text(
-                      "${context.localize.created_at} ${context.getTheLatesCreatedDateGuide(questions: value.questions)}",
+                      "${context.localize.created_at} ${context.getTheLatesCreatedDateGuideX(questions: value.questions)}",
                       style: context.textTheme.bodyGrey,
                       textAlign: TextAlign.end,
                     ),
                     Text(
-                      "${context.localize.last_modified} ${context.getTheLatesUpdatedDateGuide(questions: value.questions)}",
+                      "${context.localize.last_modified} ${context.getTheLatesUpdatedDateGuideX(questions: value.questions)}",
                       style: context.textTheme.bodyGrey,
                       textAlign: TextAlign.end,
                     ),

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -86,12 +86,12 @@ class _GuideDetailDataView extends ConsumerWidget {
                 child: Column(
                   children: [
                     Text(
-                      "${context.localize.created_at} ${context.getTheLatesCreatedDateGuide(questions: value.questions) ?? context.localize.not_date_available}",
+                      "${context.localize.created_at} ${context.getTheLatesCreatedDateGuide(questions: value.questions)}",
                       style: context.textTheme.bodyGrey,
                       textAlign: TextAlign.end,
                     ),
                     Text(
-                      "${context.localize.last_modified} ${context.getTheLatesUpdatedDateGuide(questions: value.questions) ?? context.localize.not_date_available}",
+                      "${context.localize.last_modified} ${context.getTheLatesUpdatedDateGuide(questions: value.questions)}",
                       style: context.textTheme.bodyGrey,
                       textAlign: TextAlign.end,
                     ),

--- a/lib/features/guide_detail_view/repository/getGuideDetails.graphql
+++ b/lib/features/guide_detail_view/repository/getGuideDetails.graphql
@@ -9,6 +9,8 @@ query GetGuideDetails($id: ID!) {
             FAQ_id {
                 question,
                 answer
+              	date_created
+              	date_updated
             }
         }
     }

--- a/lib/features/guide_detail_view/repository/getGuideDetails.graphql
+++ b/lib/features/guide_detail_view/repository/getGuideDetails.graphql
@@ -1,17 +1,17 @@
 query GetGuideDetails($id: ID!) {
-    FAQ_Types_by_id(id: $id){
-        name,
-        cover {
-            filename_disk
-        },
-        description,
-        questions {
-            FAQ_id {
-                question,
-                answer
-              	date_created
-              	date_updated
-            }
-        }
+  FAQ_Types_by_id(id: $id) {
+    name
+    cover {
+      filename_disk
     }
+    description
+    questions {
+      FAQ_id {
+        question
+        answer
+        date_created
+        date_updated
+      }
+    }
+  }
 }

--- a/lib/features/guide_detail_view/utils/get_the_latest_date.dart
+++ b/lib/features/guide_detail_view/utils/get_the_latest_date.dart
@@ -8,8 +8,7 @@ extension GetTheLatestDateGuide on BuildContext {
   String? getTheLatesCreatedDateGuideX({
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
-    final DateTime? newestDate = questions
-        ?.whereNonNull
+    final DateTime? newestDate = questions?.whereNonNull
         .map((e) => e.FAQ_id!.date_created!)
         .reduce((a, b) => a.isAfter(b) ? a : b);
 
@@ -20,8 +19,7 @@ extension GetTheLatestDateGuide on BuildContext {
   String? getTheLatesUpdatedDateGuideX({
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
-    final DateTime? newestDate = questions
-        ?.whereNonNull
+    final DateTime? newestDate = questions?.whereNonNull
         .map((e) => e.FAQ_id!.date_updated!)
         .reduce((a, b) => a.isAfter(b) ? a : b);
 

--- a/lib/features/guide_detail_view/utils/get_the_latest_date.dart
+++ b/lib/features/guide_detail_view/utils/get_the_latest_date.dart
@@ -1,0 +1,30 @@
+import "package:flutter/material.dart";
+import "package:intl/intl.dart";
+
+import "../repository/getGuideDetails.graphql.dart";
+
+extension GetTheLatestDateGuide on BuildContext {
+  String? getTheLatesCreatedDateGuide({
+    List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
+  }) {
+    final DateTime? newestDate = questions
+        ?.where((e) => e?.FAQ_id?.date_created != null)
+        .map((e) => e!.FAQ_id!.date_created!)
+        .reduce((a, b) => a.isAfter(b) ? a : b);
+
+    final DateFormat formatter = DateFormat("dd.MM.yyyy");
+    return newestDate != null ? formatter.format(newestDate) : null;
+  }
+
+  String? getTheLatesUpdatedDateGuide({
+    List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
+  }) {
+    final DateTime? newestDate = questions
+        ?.where((e) => e?.FAQ_id?.date_updated != null)
+        .map((e) => e!.FAQ_id!.date_updated!)
+        .reduce((a, b) => a.isAfter(b) ? a : b);
+
+    final DateFormat formatter = DateFormat("dd.MM.yyyy");
+    return newestDate != null ? formatter.format(newestDate) : null;
+  }
+}

--- a/lib/features/guide_detail_view/utils/get_the_latest_date.dart
+++ b/lib/features/guide_detail_view/utils/get_the_latest_date.dart
@@ -4,7 +4,7 @@ import "package:intl/intl.dart";
 import "../repository/getGuideDetails.graphql.dart";
 
 extension GetTheLatestDateGuide on BuildContext {
-  String? getTheLatesCreatedDateGuide({
+  String? getTheLatesCreatedDateGuideX({
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
     final DateTime? newestDate = questions
@@ -16,7 +16,7 @@ extension GetTheLatestDateGuide on BuildContext {
     return newestDate != null ? formatter.format(newestDate) : null;
   }
 
-  String? getTheLatesUpdatedDateGuide({
+  String? getTheLatesUpdatedDateGuideX({
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
     final DateTime? newestDate = questions

--- a/lib/features/guide_detail_view/utils/get_the_latest_date.dart
+++ b/lib/features/guide_detail_view/utils/get_the_latest_date.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:intl/intl.dart";
 
+import "../../../utils/where_non_null_iterable.dart";
 import "../repository/getGuideDetails.graphql.dart";
 
 extension GetTheLatestDateGuide on BuildContext {
@@ -8,8 +9,8 @@ extension GetTheLatestDateGuide on BuildContext {
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
     final DateTime? newestDate = questions
-        ?.where((e) => e?.FAQ_id?.date_created != null)
-        .map((e) => e!.FAQ_id!.date_created!)
+        ?.whereNonNull
+        .map((e) => e.FAQ_id!.date_created!)
         .reduce((a, b) => a.isAfter(b) ? a : b);
 
     final DateFormat formatter = DateFormat("dd.MM.yyyy");
@@ -20,8 +21,8 @@ extension GetTheLatestDateGuide on BuildContext {
     List<Query$GetGuideDetails$FAQ_Types_by_id$questions?>? questions,
   }) {
     final DateTime? newestDate = questions
-        ?.where((e) => e?.FAQ_id?.date_updated != null)
-        .map((e) => e!.FAQ_id!.date_updated!)
+        ?.whereNonNull
+        .map((e) => e.FAQ_id!.date_updated!)
         .reduce((a, b) => a.isAfter(b) ? a : b);
 
     final DateFormat formatter = DateFormat("dd.MM.yyyy");

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -113,5 +113,8 @@
         "example": "15"
       }
     }
-  }
+  },
+  "last_modified": "Ostatnia modyfikacja",
+  "created_at": "Utworzono",
+  "not_date_available": "Brak daty"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -114,7 +114,6 @@
       }
     }
   },
-  "last_modified": "Ostatnia modyfikacja",
-  "created_at": "Utworzono",
-  "not_date_available": "Brak daty"
+  "last_modified": "Ostatnia aktualizacja",
+  "created_at": "Utworzono"
 }


### PR DESCRIPTION
Okay, I added dates
 - last updated 
 - created
 to every guide on detail's page. I think extracting the newest date on modified and created from all questions faq's. If you think there is the better option such us dates under each faq let me know!

ss's:
<img width="271" alt="image" src="https://github.com/user-attachments/assets/251de96f-3e3b-40ff-853e-3df337d899e8">
