### PR TITLE
feature: change text-align justify to left

### DIFF
--- a/lib/features/about_us_view/utils/html_util_extensions.dart
+++ b/lib/features/about_us_view/utils/html_util_extensions.dart
@@ -26,7 +26,7 @@ extension IsLinkTagX on html.Element {
 extension CustomHtmlStylesX on BuildContext {
   Map<String, String>? customStylesBuilder(html.Element element) {
     return {
-      if (!element.hasTextAlign) "text-align": "justify",
+      if (!element.hasTextAlign) "text-align": "left",
       if (element.isH1) "font-size": "20px",
       if (element.isLink) "color": colorTheme.orangePomegranade.htmlFormat,
       "text-decoration-color": colorTheme.orangePomegranade.htmlFormat,


### PR DESCRIPTION
1. Justify removed on html widget
2. If sci club hasn't set up it to justify by default is aligned to left
3. Guide text align is to left

ss's:
<img width="246" alt="image" src="https://github.com/user-attachments/assets/94c8557c-7a72-4536-abd5-9c1145adf870">
<img width="274" alt="image" src="https://github.com/user-attachments/assets/7533762e-035d-4aee-938c-9cfe36171224">
