### PR TITLE
feat: change pomegrenade underline on not link do black

### DIFF
--- a/lib/features/about_us_view/utils/html_util_extensions.dart
+++ b/lib/features/about_us_view/utils/html_util_extensions.dart
@@ -21,6 +21,10 @@ extension IsLinkTagX on html.Element {
   bool get hasTextAlign {
     return outerHtml.contains("text-align");
   }
+
+  bool get hasUnderline {
+    return outerHtml.contains("text-decoration: underline");
+  }
 }
 
 extension CustomHtmlStylesX on BuildContext {
@@ -30,6 +34,7 @@ extension CustomHtmlStylesX on BuildContext {
       if (element.isH1) "font-size": "20px",
       if (element.isLink) "color": colorTheme.orangePomegranade.htmlFormat,
       "text-decoration-color": colorTheme.orangePomegranade.htmlFormat,
+      if (element.hasUnderline) "text-decoration-color": colorTheme.blackMirage.htmlFormat,
     };
   }
 }


### PR DESCRIPTION
changed underline color to black mirage by default on element which contains underline but are not links 

some ss's:
<img width="268" alt="image" src="https://github.com/user-attachments/assets/f4576a67-3e4a-49ea-8208-8ed9c9a9f162">
