### PR TITLE
feat: handle in app deep links

### DIFF
--- a/lib/config/url_config.dart
+++ b/lib/config/url_config.dart
@@ -1,4 +1,6 @@
 abstract class UrlConfig {
   static const academicCalendarUrl =
       "https://pwr.edu.pl/studenci/kalendarz-akademicki";
+
+  static const topwrUrl = "https://topwr.solvro.pl/";
 }

--- a/lib/features/navigator/navigation_controller.dart
+++ b/lib/features/navigator/navigation_controller.dart
@@ -25,8 +25,7 @@ class NavigationController extends _$NavigationController {
   Iterable<TRoute> get _stack =>
       _router?.stackData.map((e) => e.route.toPageRouteInfo()) ?? [];
 
-  Future<void> push(TRoute route) async {
-    final popFutureResults = _router?.push(route); // push the route
+  Future<void> keepTrackOfTabBarState(Future<void>? popFutureResults) async {
     await Future.delayed(
       Duration.zero,
       refreshState, // refresh the state after the push
@@ -34,6 +33,16 @@ class NavigationController extends _$NavigationController {
     // await the route's pop
     if (popFutureResults != null) await popFutureResults;
     refreshState(); // refresh the state after the pop
+  }
+
+  Future<void> push(TRoute route) async {
+    final popFutureResults = _router?.push(route); // push the route
+    await keepTrackOfTabBarState(popFutureResults);
+  }
+
+  Future<void> pushNamed(String uri) async {
+    final popFutureResults = _router?.pushNamed(uri); // push the route
+    await keepTrackOfTabBarState(popFutureResults);
   }
 
   /// this is called only when you actually **click** in the nav tab bar

--- a/lib/features/navigator/utils/navigation_commands.dart
+++ b/lib/features/navigator/utils/navigation_commands.dart
@@ -68,4 +68,8 @@ extension NavigationX on WidgetRef {
   Future<void> navigateGuideDetail(String id) async {
     await _router.push(GuideDetailRoute(id: id));
   }
+
+  Future<void> navigateNamedUri(String uri) async {
+    await _router.pushNamed(uri);
+  }
 }

--- a/lib/utils/launch_url_util.dart
+++ b/lib/utils/launch_url_util.dart
@@ -1,33 +1,23 @@
-import "package:collection/collection.dart";
+import "dart:async";
+
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:url_launcher/url_launcher.dart";
 
-import "../features/buildings_view/repository/buildings_repository.dart";
+import "../config/url_config.dart";
 import "../features/navigator/utils/navigation_commands.dart";
 
 extension LaunchUrlUtilX on WidgetRef? {
   Future<bool> launch(String uriStr) async {
-    if (this != null && uriStr.startsWith("topwr:")) {
-      return this!._launchTopwrLink(uriStr);
+    if (this != null && uriStr.startsWith(UrlConfig.topwrUrl)) {
+      final urlWithoutDomain = uriStr.split(UrlConfig.topwrUrl).last;
+      unawaited(
+        this!.navigateNamedUri(urlWithoutDomain),
+      );
+      return true;
     }
     final uri = Uri.parse(uriStr);
     if (await canLaunchUrl(uri)) {
       return launchUrl(uri);
-    }
-    return false;
-  }
-}
-
-extension _LaunchTopwrRouteX on WidgetRef {
-  // TODO(simon-the-shark): implement proper applinks or deeplinks
-  Future<bool> _launchTopwrLink(String uriStr) async {
-    if (uriStr.startsWith("topwr:buildings/")) {
-      final id = uriStr.replaceFirst("topwr:buildings/", "");
-      final buildings = await read(buildingsRepositoryProvider.future);
-      final building = buildings.firstWhereOrNull((i) => i.id == id);
-      if (building == null) return false;
-      await navigateBuilding(building);
-      return true;
     }
     return false;
   }


### PR DESCRIPTION
so previously if there was a deeplink in some text or guide or smth we just opened it like any other and relied on the os system to open good tab in our app.

And it even kinda worked. But had some drawbacks:
1. IOS didn't work (xd) - generally in this scenario ios never works (at least that's what i read) so this change is needed here. If we open a link ios assume we can't handle it internally, which is not the case here. we need to handle it ourselves. Disclaimer: i don't think ios deeplinks work at all for our app, but this change removes the worst case where someone can notice it.

2. on android it worked but had one drawback: back button didn't move us back to the place where we opened it. Which imo is kinda bad UX. Now you can always make a nice return to the previous screen.