### PR TITLE
Fix: fix chart labels

### DIFF
--- a/lib/features/parking_chart/chart_elements/labels_left.dart
+++ b/lib/features/parking_chart/chart_elements/labels_left.dart
@@ -14,7 +14,7 @@ class LeftLabels extends AxisTitles {
       : super(
           sideTitles: SideTitles(
             showTitles: true,
-            reservedSize: 30,
+            reservedSize: 32,
             getTitlesWidget: (value, meta) {
               if (value == meta.max && meta.isMaxLabelOverlapping) {
                 return const SizedBox.shrink();


### PR DESCRIPTION
#243 

- I couldn't reproduce the bug. Tested on various devices (different width and height of the screen), everything worked fine.  
- I've decided to increase `reservedSize` value from 30 to 32. I think that will resolve imo rare issue. 