### PR TITLE
Add padding to all elements if there is system padding

### DIFF
--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -19,6 +19,9 @@ class HomeView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final safeAreaInsets = MediaQuery.of(context).padding;
+    final horizontalPadding = safeAreaInsets.left;
+
     final sections = [
       const AcademicCalendarConsumer(),
       const ParkingsSection(),
@@ -27,17 +30,34 @@ class HomeView extends StatelessWidget {
       const NewsSection(),
       const DepartmentsSection(),
     ].lock;
+
     return Scaffold(
       backgroundColor: context.colorTheme.whiteSoap,
-      appBar: LogoAppBar(context),
-      body: KeepAliveHomeViewProviders(
-        child: ListView.separated(
-          padding: const EdgeInsets.only(bottom: HomeViewConfig.bottomPadding),
-          itemBuilder: (context, index) => sections[index],
-          separatorBuilder: (context, index) => SizedBox(
-            height: index == 1 ? 0 : HomeViewConfig.paddingMedium,
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.only(left: horizontalPadding),
+            child: LogoAppBar(context),
           ),
-          itemCount: sections.length,
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.only(
+            left: horizontalPadding, // Align with the top bar
+            right: safeAreaInsets.right,
+            bottom: HomeViewConfig.bottomPadding,
+          ),
+          child: KeepAliveHomeViewProviders(
+            child: ListView.separated(
+              itemBuilder: (context, index) => sections[index],
+              separatorBuilder: (context, index) => SizedBox(
+                height: index == 1 ? 0 : HomeViewConfig.paddingMedium,
+              ),
+              itemCount: sections.length,
+            ),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
By default AppBar adds padding if there is notch or any system padding.
To fix we can add the same padding to others elements and align them in column with logo.