### PR TITLE
feat: add navigation aware back button

### DIFF
--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -45,13 +45,17 @@ extension IsRouteATabViewX on PageRouteInfo<dynamic> {
 
   bool get isTabView => routeName.isTabView;
 
-  String? niceRouteName(BuildContext context) {
+  String? getFormatedRouteName(BuildContext context) {
     return switch (routeName) {
       HomeRoute.name => context.localize.home_screen,
       NavigationTabRoute.name => context.localize.other_view,
       DepartmentsRoute.name => context.localize.departments,
       SksMenuRoute.name => context.localize.sks_menu,
       ScienceClubsRoute.name => context.localize.scientific_cirlces,
+      GuideRoute.name => context.localize.guide,
+      BuildingsRoute.name => context.localize.buildings_title,
+      ParkingsRoute.name => context.localize.parkings_title,
+      DepartmentDetailRoute.name => context.localize.department,
       _ => null,
     };
   }

--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -2,7 +2,6 @@ import "package:auto_route/auto_route.dart";
 import "package:collection/collection.dart";
 import "package:flutter/material.dart";
 
-import "../features/about_us_view/about_us_view.dart";
 import "../features/bottom_nav_bar/bottom_nav_bar_icon_icons.icons.dart";
 import "../features/navigator/app_router.dart";
 import "../features/parkings_view/widgets/parkings_icons.icons.dart";

--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -2,9 +2,11 @@ import "package:auto_route/auto_route.dart";
 import "package:collection/collection.dart";
 import "package:flutter/material.dart";
 
+import "../features/about_us_view/about_us_view.dart";
 import "../features/bottom_nav_bar/bottom_nav_bar_icon_icons.icons.dart";
 import "../features/navigator/app_router.dart";
 import "../features/parkings_view/widgets/parkings_icons.icons.dart";
+import "../utils/context_extensions.dart";
 
 enum NavBarEnum {
   home(BottomNavBarIcon.home_icon, 26, "Home"),
@@ -43,4 +45,15 @@ extension IsRouteATabViewX on PageRouteInfo<dynamic> {
   NavBarEnum? get tabBarEnum => routeName.tabBarEnum;
 
   bool get isTabView => routeName.isTabView;
+
+  String? niceRouteName(BuildContext context) {
+    return switch (routeName) {
+      HomeRoute.name => context.localize.home_screen,
+      NavigationTabRoute.name => context.localize.other_view,
+      DepartmentsRoute.name => context.localize.departments,
+      SksMenuRoute.name => context.localize.sks_menu,
+      ScienceClubsRoute.name => context.localize.scientific_cirlces,
+      _ => null,
+    };
+  }
 }

--- a/lib/features/about_us_view/about_us_view.dart
+++ b/lib/features/about_us_view/about_us_view.dart
@@ -24,7 +24,7 @@ class AboutUsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: DetailViewAppBar(title: context.localize.guide),
+      appBar: DetailViewAppBar(),
       body: const _AboutUsView(),
     );
   }

--- a/lib/features/department_detail_view/department_detail_view.dart
+++ b/lib/features/department_detail_view/department_detail_view.dart
@@ -28,7 +28,7 @@ class DepartmentDetailView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(departmentDetailsRepositoryProvider(id));
     return Scaffold(
-      appBar: DetailViewAppBar(title: context.localize.departments),
+      appBar: DetailViewAppBar(),
       body: switch (state) {
         AsyncError(:final error) => MyErrorWidget(error),
         AsyncValue(:final DepartmentDetails value) => CustomScrollView(

--- a/lib/features/departments_view/departments_view.dart
+++ b/lib/features/departments_view/departments_view.dart
@@ -37,7 +37,6 @@ class _DepartmentsView extends ConsumerWidget {
     return Scaffold(
       appBar: SearchBoxAppBar(
         addLeadingPopButton: true,
-        leadingButtonTitle: context.localize.other_view,
         context,
         title: context.localize.departments,
         onQueryChanged: ref

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -31,7 +31,7 @@ class GuideDetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: DetailViewAppBar(title: context.localize.guide),
+      appBar: DetailViewAppBar(),
       body: _GuideDetailDataView(id: id),
     );
   }

--- a/lib/features/navigation_tab_view/navigation_tab_view.dart
+++ b/lib/features/navigation_tab_view/navigation_tab_view.dart
@@ -48,9 +48,7 @@ class NavigationTabView extends ConsumerWidget {
       ),
       _NavigationRow(
         child1: SmallTileCard(
-          onTap: () async => ref.navigateToSksMenu(
-            appBarPopTitle: context.localize.other_view,
-          ),
+          onTap: ref.navigateToSksMenu,
           title: context.localize.sks_full_name,
           icon: const Icon(
             Icons.restaurant_menu,

--- a/lib/features/navigator/utils/navigation_commands.dart
+++ b/lib/features/navigator/utils/navigation_commands.dart
@@ -73,11 +73,7 @@ extension NavigationX on WidgetRef {
     await _router.pushNamed(uri);
   }
 
-  Future<void> navigateToSksMenu({String? appBarPopTitle}) async {
-    if (appBarPopTitle != null) {
-      await _router.push(SksMenuRoute(appBarPopTitle: appBarPopTitle));
-    } else {
-      await _router.push(SksMenuRoute());
-    }
+  Future<void> navigateToSksMenu() async {
+    await _router.push(const SksMenuRoute());
   }
 }

--- a/lib/features/science_club_detail_view/science_club_detail_view.dart
+++ b/lib/features/science_club_detail_view/science_club_detail_view.dart
@@ -31,7 +31,7 @@ class ScienceClubDetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: DetailViewAppBar(title: context.localize.study_circles),
+      appBar: DetailViewAppBar(),
       body: _SciClubDetailDataView(id),
     );
   }

--- a/lib/features/science_clubs_view/widgets/sci_clubs_scaffold.dart
+++ b/lib/features/science_clubs_view/widgets/sci_clubs_scaffold.dart
@@ -15,7 +15,6 @@ class SciClubsScaffold extends ConsumerWidget {
     return Scaffold(
       appBar: SearchBoxAppBar(
         addLeadingPopButton: true,
-        leadingButtonTitle: context.localize.other_view,
         context,
         title: context.localize.study_circles,
         onQueryChanged: ref

--- a/lib/features/sks-menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks-menu/presentation/sks_menu_screen.dart
@@ -21,11 +21,7 @@ import "widgets/sks_menu_section.dart";
 
 @RoutePage()
 class SksMenuView extends ConsumerWidget {
-  const SksMenuView({
-    super.key,
-    this.appBarPopTitle,
-  });
-  final String? appBarPopTitle;
+  const SksMenuView({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -39,7 +35,6 @@ class SksMenuView extends ConsumerWidget {
               lastUpdate: DateTime.now(),
               meals: List.empty(),
             ),
-        appBarPopTitle,
       ),
       error: (error, stackTrace) => _SKSMenuLottieAnimation(error: error),
       loading: () => const Scaffold(
@@ -52,10 +47,9 @@ class SksMenuView extends ConsumerWidget {
 }
 
 class _SksMenuView extends StatelessWidget {
-  const _SksMenuView(this.sksMenuData, this.appBarPopTitle);
+  const _SksMenuView(this.sksMenuData);
 
   final SksMenuResponse sksMenuData;
-  final String? appBarPopTitle;
   @override
   Widget build(BuildContext context) {
     if (!sksMenuData.isMenuOnline) {
@@ -63,7 +57,6 @@ class _SksMenuView extends StatelessWidget {
     }
     return Scaffold(
       appBar: DetailViewAppBar(
-        title: appBarPopTitle ?? context.localize.home_screen,
         actions: const [
           SksUserDataButton(),
         ],

--- a/lib/widgets/detail_views/detail_view_app_bar.dart
+++ b/lib/widgets/detail_views/detail_view_app_bar.dart
@@ -5,13 +5,12 @@ import "pop_button.dart";
 class DetailViewAppBar extends AppBar {
   DetailViewAppBar({
     super.key,
-    required String title,
     super.actions,
   }) : super(
           centerTitle: false,
           automaticallyImplyLeading: false,
           scrolledUnderElevation: 0,
           titleSpacing: 4,
-          title: DetailViewPopButton(title),
+          title: const DetailViewPopButton(),
         );
 }

--- a/lib/widgets/detail_views/pop_button.dart
+++ b/lib/widgets/detail_views/pop_button.dart
@@ -1,7 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
-import '../../config/nav_bar_config.dart';
+import "../../config/nav_bar_config.dart";
 import "../../features/navigator/navigation_controller.dart";
 import "../../theme/app_theme.dart";
 

--- a/lib/widgets/detail_views/pop_button.dart
+++ b/lib/widgets/detail_views/pop_button.dart
@@ -11,10 +11,12 @@ class DetailViewPopButton extends ConsumerWidget {
   });
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final title = ref
-        .watch(navigationControllerProvider)
-        .previousView
-        ?.niceRouteName(context);
+    final currentRoute = ModalRoute.of(context)?.settings.name;
+    final title = currentRoute == null
+        ? null
+        : ref
+            .watch(previousRouteOnStackProvider(currentRoute))
+            ?.getFormatedRouteName(context);
 
     return TextButton(
       onPressed: () {

--- a/lib/widgets/detail_views/pop_button.dart
+++ b/lib/widgets/detail_views/pop_button.dart
@@ -1,15 +1,21 @@
 import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import '../../config/nav_bar_config.dart';
+import "../../features/navigator/navigation_controller.dart";
 import "../../theme/app_theme.dart";
 
-class DetailViewPopButton extends StatelessWidget {
-  const DetailViewPopButton(
-    this.title, {
+class DetailViewPopButton extends ConsumerWidget {
+  const DetailViewPopButton({
     super.key,
   });
-  final String? title;
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final title = ref
+        .watch(navigationControllerProvider)
+        .previousView
+        ?.niceRouteName(context);
+
     return TextButton(
       onPressed: () {
         Navigator.pop(context);

--- a/lib/widgets/search_box_app_bar.dart
+++ b/lib/widgets/search_box_app_bar.dart
@@ -19,7 +19,6 @@ class SearchBoxAppBar extends AppBar {
     VoidCallback? onSearchBoxTap,
     double bottomPadding = defaultBottomPadding,
     bool addLeadingPopButton = false,
-    String? leadingButtonTitle,
   }) : super(
           title: Text(title),
           titleTextStyle: context.textTheme.headline,
@@ -28,12 +27,12 @@ class SearchBoxAppBar extends AppBar {
           centerTitle: addLeadingPopButton,
           titleSpacing: addLeadingPopButton ? 0 : defaultHorizontalPadding,
           automaticallyImplyLeading: false,
-          leading: addLeadingPopButton && leadingButtonTitle != null
-              ? Align(
+          leading: addLeadingPopButton
+              ? const Align(
                   alignment: Alignment.centerLeft,
                   child: Padding(
-                    padding: const EdgeInsets.only(left: 4),
-                    child: DetailViewPopButton(leadingButtonTitle),
+                    padding: EdgeInsets.only(left: 4),
+                    child: DetailViewPopButton(),
                   ),
                 )
               : null,


### PR DESCRIPTION
This has started as simple button's text fix, but ended up with a nice reusable feature.

Now the `DetailViewPopButton` that exists in some of our app bars extracts the label from the navigation stack, so no hardcoding is needed for it to have a proper button title.

This is made by @thesun901, with my noticable involvement, so you guys gotta make us a review @mikolaj-jalocha @tomasz-trela 

@thesun901 can make a review too to see and review my latest changes. 

tell us what you think :P



### Example sss

![Zrzut ekranu 2024-11-29 o 00 19 37](https://github.com/user-attachments/assets/4590ba8e-b19a-444d-abba-998b6a4a531d)
![Zrzut ekranu 2024-11-29 o 00 20 08](https://github.com/user-attachments/assets/332c1c45-05b6-487f-ac0f-f1c1c224bd09)


