### PR TITLE
418 change searchs results order at buildings screen

### DIFF
--- a/lib/features/buildings_view/controllers.dart
+++ b/lib/features/buildings_view/controllers.dart
@@ -3,7 +3,6 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../utils/contains_lower_case.dart";
-import "../../utils/contains_number.dart";
 import "../map_view/controllers/active_map_marker_cntrl.dart";
 import "../map_view/controllers/bottom_sheet_controller.dart";
 import "../map_view/controllers/controllers_set.dart";
@@ -47,7 +46,7 @@ class BuildingsViewController extends _$BuildingsViewController
       case 0:
         return true;
       case 1:
-        if (_isBuildingCode(filterStr)) {
+        if (BuildingModel.isBuildingCode(filterStr)) {
           return item.name.containsBuildingCode(filterStr);
         } else {
           return item.addres.containsLowerCase(filterStr) ||
@@ -58,16 +57,6 @@ class BuildingsViewController extends _$BuildingsViewController
             item.addres.containsLowerCase(filterStr) ||
             item.naturalName.containsLowerCase(filterStr);
     }
-  }
-
-  bool _isBuildingCode(String filterStr) {
-    if (BuildingModel.buildingCodesLowerCase.contains(filterStr[0])) {
-      return true;
-    }
-    if (filterStr.containsNumber()) {
-      return true;
-    }
-    return false;
   }
 }
 

--- a/lib/features/buildings_view/controllers.dart
+++ b/lib/features/buildings_view/controllers.dart
@@ -3,6 +3,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../utils/contains_lower_case.dart";
+import "../../utils/contains_number.dart";
 import "../map_view/controllers/active_map_marker_cntrl.dart";
 import "../map_view/controllers/bottom_sheet_controller.dart";
 import "../map_view/controllers/controllers_set.dart";
@@ -42,9 +43,31 @@ class BuildingsViewController extends _$BuildingsViewController
 
   @override
   bool filterMethod(BuildingModel item, String filterStr) {
-    return item.name.containsBuildingCode(filterStr) ||
-        item.addres.containsLowerCase(filterStr) ||
-        item.naturalName.containsLowerCase(filterStr);
+    switch (filterStr.length) {
+      case 0:
+        return true;
+      case 1:
+        if (_isBuildingCode(filterStr)) {
+          return item.name.containsBuildingCode(filterStr);
+        } else {
+          return item.addres.containsLowerCase(filterStr) ||
+              item.naturalName.containsLowerCase(filterStr);
+        }
+      default:
+        return item.name.containsBuildingCode(filterStr) ||
+            item.addres.containsLowerCase(filterStr) ||
+            item.naturalName.containsLowerCase(filterStr);
+    }
+  }
+
+  bool _isBuildingCode(String filterStr) {
+    if (BuildingModel.buildingCodesLowerCase.contains(filterStr[0])) {
+      return true;
+    }
+    if (filterStr.containsNumber()) {
+      return true;
+    }
+    return false;
   }
 }
 

--- a/lib/features/buildings_view/model/building_model.dart
+++ b/lib/features/buildings_view/model/building_model.dart
@@ -1,9 +1,12 @@
 import "package:latlong2/latlong.dart";
 
+import "../../../config/map_view_config.dart";
 import "../../map_view/controllers/controllers_set.dart";
 import "../repository/buildings_repository.dart";
 
 class BuildingModel extends Building implements GoogleNavigable {
+  static Set<String> buildingCodesLowerCase = <String>{};
+
   BuildingModel.from(Building building)
       : super(
           id: building.id,
@@ -14,7 +17,11 @@ class BuildingModel extends Building implements GoogleNavigable {
           cover: building.cover,
           naturalName: building.naturalName,
           disableBuildingPrefix: building.disableBuildingPrefix,
-        );
+        ) {
+      if(building.name[1] == BuildingSearchConfig.buildingCodeSeperator) {
+        buildingCodesLowerCase.add(building.name[0].toLowerCase());
+      }
+  }
 
   @override
   LatLng get location => LatLng(latitude, longitude);

--- a/lib/features/buildings_view/model/building_model.dart
+++ b/lib/features/buildings_view/model/building_model.dart
@@ -1,11 +1,13 @@
 import "package:latlong2/latlong.dart";
 
 import "../../../config/map_view_config.dart";
+import "../../../utils/contains_number.dart";
 import "../../map_view/controllers/controllers_set.dart";
 import "../repository/buildings_repository.dart";
 
 class BuildingModel extends Building implements GoogleNavigable {
-  static Set<String> buildingCodesLowerCase = <String>{};
+  static final BuildingCodesLowerCase _buildingCodesLowerCase =
+      BuildingCodesLowerCase();
 
   BuildingModel.from(Building building)
       : super(
@@ -18,9 +20,7 @@ class BuildingModel extends Building implements GoogleNavigable {
           naturalName: building.naturalName,
           disableBuildingPrefix: building.disableBuildingPrefix,
         ) {
-      if(building.name[1] == BuildingSearchConfig.buildingCodeSeperator) {
-        buildingCodesLowerCase.add(building.name[0].toLowerCase());
-      }
+    _buildingCodesLowerCase.addBuildingCode(name);
   }
 
   @override
@@ -28,4 +28,37 @@ class BuildingModel extends Building implements GoogleNavigable {
 
   String? get addressFormatted =>
       addres?.replaceFirst(",", "\n").replaceAll("\n ", "\n");
+
+  static bool isBuildingCode(String buildingCode) {
+    return _buildingCodesLowerCase.contains(buildingCode) ||
+        buildingCode.containsNumber();
+  }
+}
+
+class BuildingCodesLowerCase {
+  final Set<String> _buildingCodesLowerCase = <String>{};
+
+  void addBuildingCode(String buildingCode) {
+    final String? code = _parseBuildingCode(buildingCode);
+    if (code != null) {
+      _buildingCodesLowerCase.add(code.toLowerCase());
+    }
+  }
+
+  Set<String> get buildingCodesLowerCase => _buildingCodesLowerCase;
+
+  String? _parseBuildingCode(String buildingName) {
+    final List<String> separatedBuildingName =
+        buildingName.split(BuildingSearchConfig.buildingCodeSeperator);
+
+    if (separatedBuildingName.length < 2) {
+      return null;
+    } else {
+      return separatedBuildingName[0];
+    }
+  }
+
+  bool contains(String buildingCode) {
+    return _buildingCodesLowerCase.contains(buildingCode);
+  }
 }

--- a/lib/utils/contains_number.dart
+++ b/lib/utils/contains_number.dart
@@ -1,0 +1,5 @@
+extension ContainsNumberX on String {
+  bool containsNumber() {
+    return contains(RegExp(r"\d"));
+  }
+}


### PR DESCRIPTION
**Repaired the issue.**
The behavior for searching buildings is now as follows:
 - No input: All buildings are displayed.
 - One-letter input: A check is performed to see if it matches a building code. If it does, buildings are filtered by the building code. If not, they are filtered by name and address.
- Multiple letters: Buildings are filtered by code, name, and address.
