### PR TITLE
fix: eliminate rotate map error

### DIFF
--- a/lib/features/map_view/controllers/map_controller.dart
+++ b/lib/features/map_view/controllers/map_controller.dart
@@ -17,7 +17,9 @@ class MyMapController<T extends GoogleNavigable> {
   final _controllerCompleter = Completer<AnimatedMapController>();
   Future<AnimatedMapController> get _controller => _controllerCompleter.future;
   void completeController(AnimatedMapController controller) {
-    _controllerCompleter.complete(controller);
+    if (!_controllerCompleter.isCompleted) {
+      _controllerCompleter.complete(controller);
+    }
   }
 
   Future<void> zoomOnMarker(T item) async {


### PR DESCRIPTION
map_controller.dart: prevent _controllerCompleter from completing AnimatedMapController again after rotating

^ pretty self explainatory - error occured because app tried to complete already completed controller.