### PR TITLE
Feat/ Adjust SKS error handling && add REST API caching

### DIFF
--- a/lib/api_base_rest/cache/cache.dart
+++ b/lib/api_base_rest/cache/cache.dart
@@ -2,6 +2,7 @@ import "dart:convert";
 import "dart:typed_data";
 
 import "package:flutter_riverpod/flutter_riverpod.dart";
+
 import "../client/dio_client.dart";
 import "cache_manager.dart";
 
@@ -9,29 +10,32 @@ extension DataCachingX on Ref {
   Future<T> getAndCacheData<T>(
     String fullUrl,
     int ttlDays,
-    T Function(Map<String, dynamic> json) fromJson,
-    bool Function() extraValidityCheck,
-  ) async {
+    T Function(Map<String, dynamic> json) fromJson, {
+    // returns true if the data is still valid
+    required bool Function(T cachedData) extraValidityCheck,
+  }) async {
     final cacheManager = watch(restCacheManagerProvider(ttlDays));
 
     final cachedFile = await cacheManager.getFileFromCache(fullUrl);
-    if (cachedFile != null && extraValidityCheck()) {
+    if (cachedFile != null) {
       final cachedData = await cachedFile.file.readAsString();
       final data = fromJson(
         jsonDecode(cachedData) as Map<String, dynamic>,
       );
-      return data;
+      if (extraValidityCheck(data)) {
+        return data;
+      }
     }
     final dio = watch(restClientProvider);
     final response = await dio.get(fullUrl);
     final sksData = fromJson(response.data as Map<String, dynamic>);
-
-    await cacheManager.putFile(
-      fullUrl,
-      Uint8List.fromList(jsonEncode(response.data).codeUnits),
-      fileExtension: CacheManagerConfig.jsonExtesion,
-    );
-
+    if (extraValidityCheck(sksData)) {
+      await cacheManager.putFile(
+        fullUrl,
+        Uint8List.fromList(utf8.encode(jsonEncode(response.data))),
+        fileExtension: CacheManagerConfig.jsonExtesion,
+      );
+    }
     return sksData;
   }
 }

--- a/lib/api_base_rest/cache/cache.dart
+++ b/lib/api_base_rest/cache/cache.dart
@@ -8,6 +8,14 @@ import "../client/offline_error.dart";
 import "cache_manager.dart";
 
 extension DataCachingX on Ref {
+  Future<void> clearCache(
+    String fullUrl,
+    int ttlDays,
+  ) async {
+    final cacheManager = watch(restCacheManagerProvider(ttlDays));
+    await cacheManager.removeFile(fullUrl);
+  }
+
   Future<T> getAndCacheData<T>(
     String fullUrl,
     int ttlDays,

--- a/lib/api_base_rest/cache/cache_manager.dart
+++ b/lib/api_base_rest/cache/cache_manager.dart
@@ -16,5 +16,5 @@ CacheManager restCacheManager(Ref ref, int ttlDays) {
 }
 
 abstract class CacheManagerConfig {
-  static const jsonExtesion = ".json";
+  static const jsonExtesion = "json";
 }

--- a/lib/api_base_rest/client/offline_error.dart
+++ b/lib/api_base_rest/client/offline_error.dart
@@ -1,0 +1,50 @@
+import "package:dio/dio.dart";
+import "package:flutter/widgets.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "dio_client.dart";
+
+class RestFrameworkOfflineException implements Exception {
+  final String message;
+  final String Function(BuildContext context) localizedMessage;
+  final VoidCallback? onRetry;
+
+  RestFrameworkOfflineException({
+    required this.localizedMessage,
+    this.onRetry,
+    this.message = "No Internet connection",
+  });
+
+  @override
+  String toString() => "RestFrameworkOfflineException: $message";
+}
+
+extension DioSafeRequestsX on Ref {
+  Future<Response<T>> safeRequest<T>(
+    Future<Response<T>> Function() request, {
+    required String Function(BuildContext context) localizedMessage,
+    VoidCallback? onRetry,
+  }) async {
+    try {
+      return await request();
+    } on DioException catch (_) {
+      throw RestFrameworkOfflineException(
+        localizedMessage: localizedMessage,
+        onRetry: onRetry,
+      );
+    }
+  }
+
+  Future<Response<T>> safeGetWatch<T>(
+    String url, {
+    required String Function(BuildContext context) localizedMessage,
+    VoidCallback? onRetry,
+  }) async {
+    final dio = watch(restClientProvider);
+    return safeRequest(
+      () => dio.get(url),
+      localizedMessage: localizedMessage,
+      onRetry: onRetry,
+    );
+  }
+}

--- a/lib/features/sks-menu/data/models/sks_menu_response.dart
+++ b/lib/features/sks-menu/data/models/sks_menu_response.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
 import "sks_menu_data.dart";
@@ -22,8 +23,8 @@ class ExtendedSksMenuResponse with _$ExtendedSksMenuResponse {
   const factory ExtendedSksMenuResponse({
     required bool isMenuOnline,
     required DateTime lastUpdate,
-    required List<SksMenuDish> meals,
-    required List<String> technicalInfos,
+    required IList<SksMenuDish> meals,
+    required IList<String> technicalInfos,
   }) = _ExtendedSksMenuResponse;
 
   factory ExtendedSksMenuResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/sks-menu/data/repository/sks_menu_repository.dart
+++ b/lib/features/sks-menu/data/repository/sks_menu_repository.dart
@@ -3,6 +3,7 @@ import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../api_base_rest/cache/cache.dart";
 import "../../../../config/env.dart";
+import "../../../../utils/context_extensions.dart";
 import "../../../../utils/datetime_utils.dart";
 import "../models/dish_category_enum.dart";
 import "../models/sks_menu_response.dart";
@@ -19,7 +20,13 @@ Future<ExtendedSksMenuResponse> getSksMenuData(Ref ref) async {
     ttlDays,
     SksMenuResponse.fromJson,
     extraValidityCheck: (data) =>
-        data.isMenuOnline && DateTime.now().date == data.lastUpdate.date,
+        data.isMenuOnline &&
+        DateTime.now().date.isSameDay(data.lastUpdate.date),
+    localizedOfflineMessage: (context) =>
+        context.localize.my_offline_error_message(
+      context.localize.sks_menu,
+    ),
+    onRetry: () => ref.invalidateSelf(),
   );
 
   final trueMeals = sksMenuResponse.meals
@@ -35,8 +42,6 @@ Future<ExtendedSksMenuResponse> getSksMenuData(Ref ref) async {
     isMenuOnline: sksMenuResponse.isMenuOnline,
     lastUpdate: sksMenuResponse.lastUpdate,
     meals: trueMeals,
-    technicalInfos: [
-      ...technicalInfos,
-    ],
+    technicalInfos: technicalInfos,
   );
 }

--- a/lib/features/sks-menu/data/repository/sks_menu_repository.dart
+++ b/lib/features/sks-menu/data/repository/sks_menu_repository.dart
@@ -1,47 +1,52 @@
-import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../api_base_rest/cache/cache.dart";
 import "../../../../config/env.dart";
-import "../../../../utils/context_extensions.dart";
 import "../../../../utils/datetime_utils.dart";
+import "../../presentation/sks_menu_screen.dart";
 import "../models/dish_category_enum.dart";
 import "../models/sks_menu_response.dart";
 
 part "sks_menu_repository.g.dart";
 
 @riverpod
-Future<ExtendedSksMenuResponse> getSksMenuData(Ref ref) async {
-  final mealsUrl = "${Env.sksUrl}/meals/current";
-  const ttlDays = 1;
+class SksMenuRepository extends _$SksMenuRepository {
+  static final _mealsUrl = "${Env.sksUrl}/meals/current";
+  static const _ttlDays = 1;
 
-  final sksMenuResponse = await ref.getAndCacheData(
-    mealsUrl,
-    ttlDays,
-    SksMenuResponse.fromJson,
-    extraValidityCheck: (data) =>
-        data.isMenuOnline &&
-        DateTime.now().date.isSameDay(data.lastUpdate.date),
-    localizedOfflineMessage: (context) =>
-        context.localize.my_offline_error_message(
-      context.localize.sks_menu,
-    ),
-    onRetry: () => ref.invalidateSelf(),
-  );
+  Future<void> clearCache() async {
+    return ref.clearCache(_mealsUrl, _ttlDays);
+  }
 
-  final trueMeals = sksMenuResponse.meals
-      .where((e) => e.category != DishCategory.technicalInfo)
-      .toList();
+  @override
+  Future<ExtendedSksMenuResponse> build() async {
+    final sksMenuResponse = await ref.getAndCacheData(
+      _mealsUrl,
+      _ttlDays,
+      SksMenuResponse.fromJson,
+      extraValidityCheck: (data) {
+        return data.isMenuOnline &&
+            DateTime.now().date.isSameDay(data.lastUpdate.date);
+      },
+      localizedOfflineMessage: SksMenuView.localizedOfflineMessage,
+      onRetry: () => ref.invalidateSelf(),
+    );
 
-  final technicalInfos = sksMenuResponse.meals
-      .where((e) => e.category == DishCategory.technicalInfo)
-      .map((e) => e.name)
-      .toList();
+    final trueMeals = sksMenuResponse.meals
+        .where((e) => e.category != DishCategory.technicalInfo)
+        .toIList();
 
-  return ExtendedSksMenuResponse(
-    isMenuOnline: sksMenuResponse.isMenuOnline,
-    lastUpdate: sksMenuResponse.lastUpdate,
-    meals: trueMeals,
-    technicalInfos: technicalInfos,
-  );
+    final technicalInfos = sksMenuResponse.meals
+        .where((e) => e.category == DishCategory.technicalInfo)
+        .map((e) => e.name)
+        .toIList();
+
+    return ExtendedSksMenuResponse(
+      isMenuOnline: sksMenuResponse.isMenuOnline,
+      lastUpdate: sksMenuResponse.lastUpdate,
+      meals: trueMeals,
+      technicalInfos: technicalInfos,
+    );
+  }
 }

--- a/lib/features/sks-menu/data/repository/sks_menu_repository.dart
+++ b/lib/features/sks-menu/data/repository/sks_menu_repository.dart
@@ -1,8 +1,9 @@
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
-import "../../../../api_base_rest/client/dio_client.dart";
+import "../../../../api_base_rest/cache/cache.dart";
 import "../../../../config/env.dart";
+import "../../../../utils/datetime_utils.dart";
 import "../models/dish_category_enum.dart";
 import "../models/sks_menu_response.dart";
 
@@ -11,15 +12,20 @@ part "sks_menu_repository.g.dart";
 @riverpod
 Future<ExtendedSksMenuResponse> getSksMenuData(Ref ref) async {
   final mealsUrl = "${Env.sksUrl}/meals/current";
+  const ttlDays = 1;
 
-  final dio = ref.read(restClientProvider);
-  final response = await dio.get(mealsUrl);
-  final SksMenuResponse sksMenuResponse =
-      SksMenuResponse.fromJson(response.data as Map<String, dynamic>);
+  final sksMenuResponse = await ref.getAndCacheData(
+    mealsUrl,
+    ttlDays,
+    SksMenuResponse.fromJson,
+    extraValidityCheck: (data) =>
+        data.isMenuOnline && DateTime.now().date == data.lastUpdate.date,
+  );
 
   final trueMeals = sksMenuResponse.meals
       .where((e) => e.category != DishCategory.technicalInfo)
       .toList();
+
   final technicalInfos = sksMenuResponse.meals
       .where((e) => e.category == DishCategory.technicalInfo)
       .map((e) => e.name)

--- a/lib/features/sks-menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks-menu/presentation/sks_menu_screen.dart
@@ -4,7 +4,6 @@ import "package:auto_route/annotations.dart";
 import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
-import "package:logger/logger.dart";
 import "package:lottie/lottie.dart";
 
 import "../../../../theme/app_theme.dart";
@@ -12,6 +11,7 @@ import "../../../config/ui_config.dart";
 import "../../../gen/assets.gen.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../widgets/my_error_widget.dart";
 import "../../../widgets/my_text_button.dart";
 import "../../sks_people_live/presentation/widgets/sks_user_data_button.dart";
 import "../data/models/sks_menu_response.dart";
@@ -34,7 +34,7 @@ class SksMenuView extends HookConsumerWidget {
     return asyncSksMenuData.when(
       data: (sksMenuData) {
         if (!sksMenuData.isMenuOnline && !isLastMenuButtonClicked.value) {
-          return _SKSMenuLottieAnimation(
+          return _SKSMenuUnavailableAnimation(
             onShowLastMenuTap: () {
               isLastMenuButtonClicked.value = true;
             },
@@ -45,7 +45,14 @@ class SksMenuView extends HookConsumerWidget {
           isLastMenuButtonClicked: isLastMenuButtonClicked.value,
         );
       },
-      error: (error, stackTrace) => _SKSMenuLottieAnimation(error: error),
+      error: (error, stackTrace) => Scaffold(
+        appBar: DetailViewAppBar(
+          actions: const [
+            SksUserDataButton(),
+          ],
+        ),
+        body: MyErrorWidget(error),
+      ),
       loading: () => const Scaffold(
         body: Center(
           child: SksMenuViewLoading(),
@@ -67,7 +74,7 @@ class _SksMenuView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!isLastMenuButtonClicked && !sksMenuData.isMenuOnline) {
-      return const _SKSMenuLottieAnimation();
+      return const _SKSMenuUnavailableAnimation();
     }
     return Scaffold(
       appBar: DetailViewAppBar(
@@ -102,22 +109,14 @@ class _SksMenuView extends StatelessWidget {
   }
 }
 
-class _SKSMenuLottieAnimation extends HookWidget {
-  const _SKSMenuLottieAnimation({
-    this.error,
-    this.onShowLastMenuTap,
-  });
+class _SKSMenuUnavailableAnimation extends HookWidget {
+  const _SKSMenuUnavailableAnimation({this.onShowLastMenuTap});
 
-  final Object? error;
   final VoidCallback? onShowLastMenuTap;
 
   @override
   Widget build(BuildContext context) {
     final isAnimationCompleted = useState(false);
-
-    if (error != null) {
-      Logger().e(error.toString());
-    }
     final animationSize = MediaQuery.sizeOf(context).width * 0.6;
 
     return Scaffold(
@@ -167,12 +166,6 @@ class _SKSMenuLottieAnimation extends HookWidget {
                       ),
                       textAlign: TextAlign.center,
                     ),
-                    if (error != null)
-                      Text(
-                        error.toString(),
-                        style: context.textTheme.titleGrey,
-                        textAlign: TextAlign.center,
-                      ),
                     if (onShowLastMenuTap != null)
                       Padding(
                         padding: const EdgeInsets.only(top: 12),

--- a/lib/features/sks-menu/presentation/widgets/sks_menu_section.dart
+++ b/lib/features/sks-menu/presentation/widgets/sks_menu_section.dart
@@ -9,7 +9,7 @@ import "sks_menu_tiles.dart";
 class SksMenuSection extends StatelessWidget {
   const SksMenuSection(this.data, {super.key});
 
-  final List<SksMenuDish> data;
+  final IList<SksMenuDish> data;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/sks-menu/presentation/widgets/technical_message.dart
+++ b/lib/features/sks-menu/presentation/widgets/technical_message.dart
@@ -4,16 +4,18 @@ import "../../../../config/ui_config.dart";
 import "../../../../theme/app_theme.dart";
 import "../../data/models/dish_category_enum.dart";
 
+enum AlertType { info, error }
+
 class TechnicalMessage extends StatelessWidget {
   const TechnicalMessage({
     super.key,
     required this.message,
     this.title,
-    this.color,
+    this.alertType = AlertType.error,
   });
   final String message;
   final String? title;
-  final Color? color;
+  final AlertType alertType;
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -21,9 +23,12 @@ class TechnicalMessage extends StatelessWidget {
         HomeViewConfig.paddingMedium,
       ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(8),
+        borderRadius:
+            BorderRadius.circular(AppWidgetsConfig.borderRadiusMedium),
         child: ColoredBox(
-          color: color ?? context.colorTheme.orangePomegranade,
+          color: alertType == AlertType.error
+              ? context.colorTheme.orangePomegranade
+              : context.colorTheme.blueAzure,
           child: ListTile(
             title: Text(
               title ?? DishCategory.technicalInfo.getLocalizedName(context),

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -191,5 +191,15 @@
   "push_notifications_dialog_info": "Obecnie nie korzystamy z powiadomień push, ale planujemy dodać je w przyszłości. Możesz wyrazić na nie zgodę już teraz.",
   "sks_menu_technical_info": "KOMUNIKAT",
   "sks_note": "UWAGA",
-  "sks_menu_you_see_last_menu": "Aktualne menu SKS jest niedostępne. Przeglądasz ostatnio dostępną wersję." 
+  "sks_menu_you_see_last_menu": "Aktualne menu SKS jest niedostępne. Przeglądasz ostatnio dostępną wersję.",
+  "my_offline_error_message": "Wystąpił błąd podczas pobierania danych dotyczących {data_type}",
+  "@my_offline_error_message": {
+    "description": "An error message with a single parameter",
+    "placeholders": {
+      "data_type": {
+        "type": "String",
+        "example": "wydziałów"
+      }
+    }
+  }
 }

--- a/lib/widgets/my_error_widget.dart
+++ b/lib/widgets/my_error_widget.dart
@@ -5,7 +5,9 @@ import "package:logger/logger.dart";
 import "package:lottie/lottie.dart";
 
 import "../api_base/query_adapter.dart";
+import "../api_base_rest/client/offline_error.dart";
 import "../config/ui_config.dart";
+import "../features/offline_messages/widgets/general_offline_message.dart";
 import "../features/offline_messages/widgets/grapgql_offline_message.dart";
 import "../features/parkings_view/api_client/iparking_commands.dart";
 import "../features/parkings_view/widgets/offline_parkings_view.dart";
@@ -32,6 +34,11 @@ class MyErrorWidget extends HookWidget {
     return switch (error) {
       ParkingsOfflineException() => const OfflineParkingsView(),
       GqlOfflineException(:final ttlKey) => OfflineGraphQLMessage(ttlKey),
+      RestFrameworkOfflineException(:final localizedMessage, :final onRetry) =>
+        OfflineMessage(
+          localizedMessage(context),
+          onRefresh: onRetry,
+        ),
       _ => Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
1. Adjusted error handling
  - previously we had shown sks animation with any error
  - now we show:
      - sks animation when the menu is not available (that's not really an exception, just a normal situation)
      - offline animation when we don't have internet connection
      - our `MyErrorWidget` on any other error


![image](https://github.com/user-attachments/assets/dbddc590-fc44-48c0-a831-17fc9f2dfe2f)
![image](https://github.com/user-attachments/assets/49399a35-b18e-461d-8d11-fa788e3ca40b)




2. Added caching
 - we cache the data for 1 day, only when the available menu is up to date
 - we always invalidate the cache when the cached data is from the previous day (after midnight)




3. pull to refresh
    - we invalidate the cache and redo the request

<img width="361" alt="Zrzut ekranu 2024-12-10 o 13 31 06" src="https://github.com/user-attachments/assets/b62b183b-2661-48b2-bb1f-7770c5e71810">

