### PR TITLE
fix(digital-guide): ui changes to amnesties and surroundings tiles

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -235,6 +235,8 @@ abstract class NavigationTabViewConfig {
 abstract class DigitalGuideConfig {
   static const symetricalPaddingSmall =
       EdgeInsets.symmetric(vertical: 4, horizontal: 4);
+  static const symetricalPaddingMedium =
+      EdgeInsets.symmetric(vertical: 8, horizontal: 8);
   static const symetricalPaddingBig =
       EdgeInsets.symmetric(vertical: 24, horizontal: 24);
   static const borderRadiusSmall = 4.0;
@@ -244,6 +246,7 @@ abstract class DigitalGuideConfig {
   static const heightMedium = 16.0;
   static const heightBig = 24.0;
   static const heightHuge = 48.0;
+  static const widePaddingMedium = EdgeInsets.symmetric(horizontal: 8);
   static const paddingSmall = 4.0;
   static const mediumButtonPadding =
       EdgeInsets.symmetric(vertical: 8, horizontal: 14);

--- a/lib/features/digital_guide_view/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide_view/presentation/digital_guide_view.dart
@@ -54,7 +54,6 @@ class _DigitalGuideView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final widgets1 = [
-      const SizedBox(height: DigitalGuideConfig.heightSmall),
       MyCachedImage(
         digitalGuideResponseExtended.imageUrl,
       ),

--- a/lib/features/digital_guide_view/presentation/widgets/accessibility_information_card.dart
+++ b/lib/features/digital_guide_view/presentation/widgets/accessibility_information_card.dart
@@ -20,7 +20,7 @@ class AccessibilityInformationCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      height: DigitalGuideConfig.paddingSmall * 2 +
+      height: DigitalGuideConfig.paddingMedium +
           DigitalGuideConfig.difficultiesCardIconSize,
       decoration: BoxDecoration(
         borderRadius:
@@ -30,7 +30,7 @@ class AccessibilityInformationCard extends StatelessWidget {
       child: Row(
         children: [
           Padding(
-            padding: DigitalGuideConfig.symetricalPaddingSmall,
+            padding: DigitalGuideConfig.widePaddingMedium,
             child: Container(
               width: DigitalGuideConfig.difficultiesCardIconSize,
               height: DigitalGuideConfig.difficultiesCardIconSize,
@@ -41,18 +41,22 @@ class AccessibilityInformationCard extends StatelessWidget {
                 color: Colors.white,
               ),
               child: Padding(
-                padding: DigitalGuideConfig.symetricalPaddingSmall,
+                padding: DigitalGuideConfig.widePaddingMedium,
                 child: SvgPicture.asset(icon),
               ),
             ),
           ),
           const SizedBox(width: DigitalGuideConfig.heightTiny),
           Expanded(
-            child: Text(
-              text,
-              style: context.textTheme.bodyWhite,
-              overflow: TextOverflow.ellipsis,
-              maxLines: 2,
+            child: Padding(
+              padding:
+                  const EdgeInsets.only(right: DigitalGuideConfig.paddingSmall),
+              child: Text(
+                text,
+                style: context.textTheme.bodyWhite,
+                overflow: TextOverflow.ellipsis,
+                maxLines: 2,
+              ),
             ),
           ),
         ],

--- a/lib/features/digital_guide_view/presentation/widgets/report_change_button.dart
+++ b/lib/features/digital_guide_view/presentation/widgets/report_change_button.dart
@@ -24,7 +24,7 @@ class ReportChangeButton extends ConsumerWidget {
               unawaited(ref.launch(emailUrl));
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: context.colorTheme.blueAzure,
+              backgroundColor: context.colorTheme.orangePomegranade,
               padding: AppWidgetsConfig.paddingMedium,
               minimumSize: const Size(144, 40),
               shape: RoundedRectangleBorder(

--- a/lib/features/digital_guide_view/tabs/amenities/presentation/amenities_expansion_tile_content.dart
+++ b/lib/features/digital_guide_view/tabs/amenities/presentation/amenities_expansion_tile_content.dart
@@ -1,6 +1,7 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/widgets.dart";
 
+import "../../../../../config/ui_config.dart";
 import "../../../../../gen/assets.gen.dart";
 import "../../../../../utils/context_extensions.dart";
 import "../../../../../utils/determine_contact_icon.dart";
@@ -17,6 +18,7 @@ class AmenitiesExpansionTileContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ContactSection(
+      topPadding: DigitalGuideConfig.heightTiny,
       list: [
         if (digitalGuideResponseExtended.canAssistanceDog)
           ContactIconsModel(

--- a/lib/features/digital_guide_view/tabs/surrounding/presentation/surroundings_expansion_tile_content.dart
+++ b/lib/features/digital_guide_view/tabs/surrounding/presentation/surroundings_expansion_tile_content.dart
@@ -53,11 +53,14 @@ class _SurroundingExpansionTileContent extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final widgets = [
+      const SizedBox(
+        height: DigitalGuideConfig.heightSmall,
+      ),
       AccessibilityInformationCardsList(
         surroundingResponse: surroundingResponse,
       ),
       const SizedBox(
-        height: DigitalGuideConfig.heightMedium,
+        height: DigitalGuideConfig.heightBig,
       ),
       BulletList(
         items: [
@@ -71,7 +74,10 @@ class _SurroundingExpansionTileContent extends ConsumerWidget {
         ].toIList(),
       ),
       const SizedBox(
-        height: DigitalGuideConfig.heightMedium,
+        height: DigitalGuideConfig.heightBig,
+      ),
+      const SizedBox(
+        height: DigitalGuideConfig.heightTiny,
       ),
       AccessibilityProfileCard(
         items: getSurroundingsCommentsList(surroundingResponse, context),
@@ -82,12 +88,15 @@ class _SurroundingExpansionTileContent extends ConsumerWidget {
       ),
       DigitalGuidePhotoRow(imageUrls: surroundingResponse.imagesUrl?.toIList()),
       const SizedBox(
-        height: DigitalGuideConfig.heightMedium,
+        height: DigitalGuideConfig.heightSmall,
       ),
       DigitalGuideNavLink(
         onTap: () => {},
         text:
             context.localize.see_all_photos(surroundingResponse.images.length),
+      ),
+      const SizedBox(
+        height: DigitalGuideConfig.heightMedium,
       ),
     ];
 

--- a/lib/widgets/detail_views/contact_section.dart
+++ b/lib/widgets/detail_views/contact_section.dart
@@ -9,16 +9,27 @@ import "../../utils/launch_url_util.dart";
 import "contact_icon_widget.dart";
 
 class ContactSection extends StatelessWidget {
-  const ContactSection({super.key, required this.list, this.title});
+  const ContactSection({
+    super.key,
+    required this.list,
+    this.title,
+    this.topPadding = 24,
+  });
 
   final IList<ContactIconsModel> list;
   final String? title;
+  final double topPadding;
 
   @override
   Widget build(BuildContext context) {
     final sorted = list.sort((a, b) => a.order.compareTo(b.order));
     return Container(
-      padding: const EdgeInsets.only(top: 24, left: 24, right: 24, bottom: 8),
+      padding: EdgeInsets.only(
+        top: topPadding,
+        left: 24,
+        right: 24,
+        bottom: 8,
+      ),
       color: context.colorTheme.greyLight,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
### Changes:

- Small paddings changes in amnesties expansion tile
- Improving visual aspect of Surroundings expension tile
- Small changes to other parts of digital guide UI


<img width="482" alt="Screenshot 2025-01-09 at 20 20 41" src="https://github.com/user-attachments/assets/7e8c0f31-99c9-4342-a4ab-3fcd1e4b2fdc" />
<img width="482" alt="Screenshot 2025-01-09 at 20 2
<img width="482" alt="Screenshot 2025-01-09 at 20 21 10" src="https://github.com/user-attachments/assets/da41a983-ccc9-47c6-934e-776e6179b554" />
<img width="482" alt="Screenshot 2025-01-09 at 20 21 23" src="https://github.com/user-attachments/assets/c35b696e-49c6-47af-8227-13eeab65e09d" />
