### PR TITLE
Round images in adapted toilets

### DIFF
--- a/lib/features/digital_guide_view/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide_view/presentation/digital_guide_view.dart
@@ -64,7 +64,8 @@ class _DigitalGuideView extends ConsumerWidget {
       const SizedBox(height: DigitalGuideConfig.heightSmall),
       SizedBox(
         height: DetailViewsConfig.imageHeight,
-        child: DigitalGuideImage(id: digitalGuideData.images[0]),
+        child:
+            DigitalGuideImage(id: digitalGuideData.images[0], zoomable: false),
       ),
       HeadlinesSection(
         name: digitalGuideData.translations.plTranslation.name,

--- a/lib/features/digital_guide_view/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide_view/presentation/digital_guide_view.dart
@@ -64,8 +64,7 @@ class _DigitalGuideView extends ConsumerWidget {
       const SizedBox(height: DigitalGuideConfig.heightSmall),
       SizedBox(
         height: DetailViewsConfig.imageHeight,
-        child:
-            DigitalGuideImage(id: digitalGuideData.images[0], zoomable: false),
+        child: DigitalGuideImage(id: digitalGuideData.images[0]),
       ),
       HeadlinesSection(
         name: digitalGuideData.translations.plTranslation.name,

--- a/lib/features/digital_guide_view/tabs/adapted_toilets/data/models/adapted_toilet.dart
+++ b/lib/features/digital_guide_view/tabs/adapted_toilets/data/models/adapted_toilet.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
@@ -19,8 +20,8 @@ class AdaptedToilet with _$AdaptedToilet {
     @JsonKey(name: "is_entrance_graphically_marked", fromJson: _stringToBool)
     required bool isEntranceGraphicallyMarked,
     @JsonKey(name: "is_marked", fromJson: _stringToBool) required bool isMarked,
-    @JsonKey(name: "images") required List<int> imagesIndices,
-    @JsonKey(name: "doors") required List<int> doorsIndices,
+    @JsonKey(name: "images") required IList<int> imagesIndices,
+    @JsonKey(name: "doors") required IList<int> doorsIndices,
   }) = _AdaptedToilet;
 
   factory AdaptedToilet.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/digital_guide_view/tabs/adapted_toilets/presentation/adapted_toilet_detail_view.dart
+++ b/lib/features/digital_guide_view/tabs/adapted_toilets/presentation/adapted_toilet_detail_view.dart
@@ -108,8 +108,13 @@ class AdaptedToiletDetailView extends ConsumerWidget {
                   return Padding(
                     padding:
                         const EdgeInsets.all(DigitalGuideConfig.heightMedium),
-                    child: DigitalGuideImage(
-                      id: adaptedToilet.imagesIndices[index],
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(
+                        DigitalGuideConfig.borderRadiusSmall,
+                      ),
+                      child: DigitalGuideImage(
+                        id: adaptedToilet.imagesIndices[index],
+                      ),
                     ),
                   );
                 },

--- a/lib/features/home_view/widgets/nav_actions_section.dart
+++ b/lib/features/home_view/widgets/nav_actions_section.dart
@@ -49,7 +49,7 @@ class NavActionsSection extends ConsumerWidget {
                 color: context.colorTheme.whiteSoap,
                 size: 32,
               ),
-              () => unawaited(ref.navigateDigitalGuide(303)),
+              () => unawaited(ref.navigateDigitalGuide(421)),
             ),
           ],
         ),


### PR DESCRIPTION
#  Round images in adapted toilets

<img width="200" alt="image" src="https://github.com/user-attachments/assets/20210876-4860-4a54-9513-91d1efcbd26b" />

# zoomable = false in digital guide view - prevents this

<img width="200" alt="image" src="https://github.com/user-attachments/assets/92b20a9b-3d03-4afb-ba97-b297ca9aef1e" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/637b8520-9a1f-405f-a3ec-50e962d635d5" />

# Additional info
I tried to use DigitalGuidePhotoRow in adapted toilets and I even fixed row stretching in this widget but it looked awkward because of the images ratio.