### PR TITLE
Feat/connect digital guide

### DIFF
--- a/lib/api_base/schema.graphql
+++ b/lib/api_base/schema.graphql
@@ -55,10 +55,6 @@ type Query {
   FieldOfStudy_by_id(id: ID!, version: String): FieldOfStudy
   FieldOfStudy_aggregated(groupBy: [String], filter: FieldOfStudy_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [FieldOfStudy_aggregated!]!
   FieldOfStudy_by_version(version: String!, id: ID!): version_FieldOfStudy
-  Buildings(filter: Buildings_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [Buildings!]!
-  Buildings_by_id(id: ID!, version: String): Buildings
-  Buildings_aggregated(groupBy: [String], filter: Buildings_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [Buildings_aggregated!]!
-  Buildings_by_version(version: String!, id: ID!): version_Buildings
   CacheReferenceNumber(version: String): CacheReferenceNumber
   CacheReferenceNumber_by_version(version: String!): version_CacheReferenceNumber
   AboutUs_Team_Social_Links(filter: AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [AboutUs_Team_Social_Links!]!
@@ -85,10 +81,6 @@ type Query {
   Scientific_Circles_by_id(id: ID!, version: String): Scientific_Circles
   Scientific_Circles_aggregated(groupBy: [String], filter: Scientific_Circles_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [Scientific_Circles_aggregated!]!
   Scientific_Circles_by_version(version: String!, id: ID!): version_Scientific_Circles
-  TeamVersions(filter: TeamVersions_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [TeamVersions!]!
-  TeamVersions_by_id(id: ID!, version: String): TeamVersions
-  TeamVersions_aggregated(groupBy: [String], filter: TeamVersions_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [TeamVersions_aggregated!]!
-  TeamVersions_by_version(version: String!, id: ID!): version_TeamVersions
   TeamVersion_Members_AboutUs_Team_Social_Links(filter: TeamVersion_Members_AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [TeamVersion_Members_AboutUs_Team_Social_Links!]!
   TeamVersion_Members_AboutUs_Team_Social_Links_by_id(id: ID!, version: String): TeamVersion_Members_AboutUs_Team_Social_Links
   TeamVersion_Members_AboutUs_Team_Social_Links_aggregated(groupBy: [String], filter: TeamVersion_Members_AboutUs_Team_Social_Links_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [TeamVersion_Members_AboutUs_Team_Social_Links_aggregated!]!
@@ -97,6 +89,14 @@ type Query {
   TeamVersion_Members_by_id(id: ID!, version: String): TeamVersion_Members
   TeamVersion_Members_aggregated(groupBy: [String], filter: TeamVersion_Members_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [TeamVersion_Members_aggregated!]!
   TeamVersion_Members_by_version(version: String!, id: ID!): version_TeamVersion_Members
+  TeamVersions(filter: TeamVersions_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [TeamVersions!]!
+  TeamVersions_by_id(id: ID!, version: String): TeamVersions
+  TeamVersions_aggregated(groupBy: [String], filter: TeamVersions_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [TeamVersions_aggregated!]!
+  TeamVersions_by_version(version: String!, id: ID!): version_TeamVersions
+  Buildings(filter: Buildings_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [Buildings!]!
+  Buildings_by_id(id: ID!, version: String): Buildings
+  Buildings_aggregated(groupBy: [String], filter: Buildings_filter, limit: Int, offset: Int, page: Int, search: String, sort: [String]): [Buildings_aggregated!]!
+  Buildings_by_version(version: String!, id: ID!): version_Buildings
 }
 
 type Scientific_Circles_Tags {
@@ -1199,76 +1199,6 @@ type version_FieldOfStudy {
   hasWeekendModeOption: Boolean
 }
 
-type Buildings {
-  id: ID!
-  name: String!
-  latitude: Float!
-  longitude: Float!
-  addres: String
-  cover(filter: directus_files_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): directus_files
-  food: Boolean
-  naturalName: String
-  disableBuildingPrefix: Boolean!
-}
-
-input Buildings_filter {
-  id: number_filter_operators
-  name: string_filter_operators
-  latitude: number_filter_operators
-  longitude: number_filter_operators
-  addres: string_filter_operators
-  cover: directus_files_filter
-  food: boolean_filter_operators
-  naturalName: string_filter_operators
-  disableBuildingPrefix: boolean_filter_operators
-  _and: [Buildings_filter]
-  _or: [Buildings_filter]
-}
-
-type Buildings_aggregated {
-  group: JSON
-  countAll: Int
-  count: Buildings_aggregated_count
-  countDistinct: Buildings_aggregated_count
-  avg: Buildings_aggregated_fields
-  sum: Buildings_aggregated_fields
-  avgDistinct: Buildings_aggregated_fields
-  sumDistinct: Buildings_aggregated_fields
-  min: Buildings_aggregated_fields
-  max: Buildings_aggregated_fields
-}
-
-type Buildings_aggregated_count {
-  id: Int
-  name: Int
-  latitude: Int
-  longitude: Int
-  addres: Int
-  cover: Int
-  food: Int
-  naturalName: Int
-  disableBuildingPrefix: Int
-}
-
-type Buildings_aggregated_fields {
-  id: Float
-  latitude: Float
-  longitude: Float
-}
-
-""""""
-type version_Buildings {
-  id: ID!
-  name: String!
-  latitude: Float!
-  longitude: Float!
-  addres: String
-  cover: JSON
-  food: Boolean
-  naturalName: String
-  disableBuildingPrefix: Boolean!
-}
-
 type CacheReferenceNumber {
   id: ID!
   status: String
@@ -1626,6 +1556,29 @@ type version_Scientific_Circles {
   links_func: count_functions
 }
 
+type TeamVersion_Members_AboutUs_Team_Social_Links {
+  id: ID!
+  TeamVersion_Members_id(filter: TeamVersion_Members_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): TeamVersion_Members
+  AboutUs_Team_Social_Links_id(filter: AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): AboutUs_Team_Social_Links
+}
+
+type TeamVersion_Members {
+  id: ID!
+  sort: Int
+  user_created: String
+  date_created: Date
+  date_created_func: datetime_functions
+  user_updated: String
+  date_updated: Date
+  date_updated_func: datetime_functions
+  name: String!
+  subtitle: String
+  photo(filter: directus_files_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): directus_files
+  appVersion(filter: TeamVersions_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): TeamVersions
+  socialLinks(filter: TeamVersion_Members_AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [TeamVersion_Members_AboutUs_Team_Social_Links]
+  socialLinks_func: count_functions
+}
+
 type TeamVersions {
   id: ID!
   sort: Int
@@ -1650,70 +1603,6 @@ input TeamVersions_filter {
   name: string_filter_operators
   _and: [TeamVersions_filter]
   _or: [TeamVersions_filter]
-}
-
-type TeamVersions_aggregated {
-  group: JSON
-  countAll: Int
-  count: TeamVersions_aggregated_count
-  countDistinct: TeamVersions_aggregated_count
-  avg: TeamVersions_aggregated_fields
-  sum: TeamVersions_aggregated_fields
-  avgDistinct: TeamVersions_aggregated_fields
-  sumDistinct: TeamVersions_aggregated_fields
-  min: TeamVersions_aggregated_fields
-  max: TeamVersions_aggregated_fields
-}
-
-type TeamVersions_aggregated_count {
-  id: Int
-  sort: Int
-  user_created: Int
-  date_created: Int
-  user_updated: Int
-  date_updated: Int
-  name: Int
-}
-
-type TeamVersions_aggregated_fields {
-  id: Float
-  sort: Float
-}
-
-""""""
-type version_TeamVersions {
-  id: ID!
-  sort: Int
-  user_created: String
-  date_created: Date
-  date_created_func: datetime_functions
-  user_updated: String
-  date_updated: Date
-  date_updated_func: datetime_functions
-  name: String
-}
-
-type TeamVersion_Members_AboutUs_Team_Social_Links {
-  id: ID!
-  TeamVersion_Members_id(filter: TeamVersion_Members_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): TeamVersion_Members
-  AboutUs_Team_Social_Links_id(filter: AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): AboutUs_Team_Social_Links
-}
-
-type TeamVersion_Members {
-  id: ID!
-  sort: Int
-  user_created: String
-  date_created: Date
-  date_created_func: datetime_functions
-  user_updated: String
-  date_updated: Date
-  date_updated_func: datetime_functions
-  name: String!
-  subtitle: String
-  photo(filter: directus_files_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): directus_files
-  appVersion(filter: TeamVersions_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): TeamVersions
-  socialLinks(filter: TeamVersion_Members_AboutUs_Team_Social_Links_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): [TeamVersion_Members_AboutUs_Team_Social_Links]
-  socialLinks_func: count_functions
 }
 
 input TeamVersion_Members_AboutUs_Team_Social_Links_filter {
@@ -1826,6 +1715,125 @@ type version_TeamVersion_Members {
   socialLinks_func: count_functions
 }
 
+type TeamVersions_aggregated {
+  group: JSON
+  countAll: Int
+  count: TeamVersions_aggregated_count
+  countDistinct: TeamVersions_aggregated_count
+  avg: TeamVersions_aggregated_fields
+  sum: TeamVersions_aggregated_fields
+  avgDistinct: TeamVersions_aggregated_fields
+  sumDistinct: TeamVersions_aggregated_fields
+  min: TeamVersions_aggregated_fields
+  max: TeamVersions_aggregated_fields
+}
+
+type TeamVersions_aggregated_count {
+  id: Int
+  sort: Int
+  user_created: Int
+  date_created: Int
+  user_updated: Int
+  date_updated: Int
+  name: Int
+}
+
+type TeamVersions_aggregated_fields {
+  id: Float
+  sort: Float
+}
+
+""""""
+type version_TeamVersions {
+  id: ID!
+  sort: Int
+  user_created: String
+  date_created: Date
+  date_created_func: datetime_functions
+  user_updated: String
+  date_updated: Date
+  date_updated_func: datetime_functions
+  name: String
+}
+
+type Buildings {
+  id: ID!
+  name: String!
+  latitude: Float!
+  longitude: Float!
+  addres: String
+  cover(filter: directus_files_filter, sort: [String], limit: Int, offset: Int, page: Int, search: String): directus_files
+  food: Boolean
+  naturalName: String
+  disableBuildingPrefix: Boolean!
+  externalDigitalGuideIdOrURL: String
+  externalDigitalGuideMode: String
+}
+
+input Buildings_filter {
+  id: number_filter_operators
+  name: string_filter_operators
+  latitude: number_filter_operators
+  longitude: number_filter_operators
+  addres: string_filter_operators
+  cover: directus_files_filter
+  food: boolean_filter_operators
+  naturalName: string_filter_operators
+  disableBuildingPrefix: boolean_filter_operators
+  externalDigitalGuideIdOrURL: string_filter_operators
+  externalDigitalGuideMode: string_filter_operators
+  _and: [Buildings_filter]
+  _or: [Buildings_filter]
+}
+
+type Buildings_aggregated {
+  group: JSON
+  countAll: Int
+  count: Buildings_aggregated_count
+  countDistinct: Buildings_aggregated_count
+  avg: Buildings_aggregated_fields
+  sum: Buildings_aggregated_fields
+  avgDistinct: Buildings_aggregated_fields
+  sumDistinct: Buildings_aggregated_fields
+  min: Buildings_aggregated_fields
+  max: Buildings_aggregated_fields
+}
+
+type Buildings_aggregated_count {
+  id: Int
+  name: Int
+  latitude: Int
+  longitude: Int
+  addres: Int
+  cover: Int
+  food: Int
+  naturalName: Int
+  disableBuildingPrefix: Int
+  externalDigitalGuideIdOrURL: Int
+  externalDigitalGuideMode: Int
+}
+
+type Buildings_aggregated_fields {
+  id: Float
+  latitude: Float
+  longitude: Float
+}
+
+""""""
+type version_Buildings {
+  id: ID!
+  name: String!
+  latitude: Float!
+  longitude: Float!
+  addres: String
+  cover: JSON
+  food: Boolean
+  naturalName: String
+  disableBuildingPrefix: Boolean!
+  externalDigitalGuideIdOrURL: String
+  externalDigitalGuideMode: String
+}
+
 type Subscription {
   directus_files_mutated(event: EventEnum): directus_files_mutated
   Scientific_Circles_Tags_mutated(event: EventEnum): Scientific_Circles_Tags_mutated
@@ -1843,7 +1851,6 @@ type Subscription {
   FAQ_Types_mutated(event: EventEnum): FAQ_Types_mutated
   Departments_Links_mutated(event: EventEnum): Departments_Links_mutated
   FieldOfStudy_mutated(event: EventEnum): FieldOfStudy_mutated
-  Buildings_mutated(event: EventEnum): Buildings_mutated
   CacheReferenceNumber_mutated(event: EventEnum): CacheReferenceNumber_mutated
   AboutUs_Team_Social_Links_mutated(event: EventEnum): AboutUs_Team_Social_Links_mutated
   FAQ_Types_FAQ_mutated(event: EventEnum): FAQ_Types_FAQ_mutated
@@ -1851,9 +1858,10 @@ type Subscription {
   Changelog_Change_mutated(event: EventEnum): Changelog_Change_mutated
   Changelog_Screenshots_mutated(event: EventEnum): Changelog_Screenshots_mutated
   Scientific_Circles_mutated(event: EventEnum): Scientific_Circles_mutated
-  TeamVersions_mutated(event: EventEnum): TeamVersions_mutated
   TeamVersion_Members_AboutUs_Team_Social_Links_mutated(event: EventEnum): TeamVersion_Members_AboutUs_Team_Social_Links_mutated
   TeamVersion_Members_mutated(event: EventEnum): TeamVersion_Members_mutated
+  TeamVersions_mutated(event: EventEnum): TeamVersions_mutated
+  Buildings_mutated(event: EventEnum): Buildings_mutated
 }
 
 type directus_files_mutated {
@@ -1958,12 +1966,6 @@ type FieldOfStudy_mutated {
   data: FieldOfStudy
 }
 
-type Buildings_mutated {
-  key: ID!
-  event: EventEnum
-  data: Buildings
-}
-
 type CacheReferenceNumber_mutated {
   key: ID!
   event: EventEnum
@@ -2006,12 +2008,6 @@ type Scientific_Circles_mutated {
   data: Scientific_Circles
 }
 
-type TeamVersions_mutated {
-  key: ID!
-  event: EventEnum
-  data: TeamVersions
-}
-
 type TeamVersion_Members_AboutUs_Team_Social_Links_mutated {
   key: ID!
   event: EventEnum
@@ -2022,4 +2018,16 @@ type TeamVersion_Members_mutated {
   key: ID!
   event: EventEnum
   data: TeamVersion_Members
+}
+
+type TeamVersions_mutated {
+  key: ID!
+  event: EventEnum
+  data: TeamVersions
+}
+
+type Buildings_mutated {
+  key: ID!
+  event: EventEnum
+  data: Buildings
 }

--- a/lib/features/buildings_view/building_tile.dart
+++ b/lib/features/buildings_view/building_tile.dart
@@ -3,9 +3,11 @@ import "dart:async";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../../config/ui_config.dart";
 import "../../theme/app_theme.dart";
 import "../../utils/context_extensions.dart";
 import "../../widgets/wide_tile_card.dart";
+import "../navigator/utils/navigation_commands.dart";
 import "controllers.dart";
 import "model/building_model.dart";
 import "utils/utils.dart";
@@ -21,18 +23,46 @@ class BuildingTile extends ConsumerWidget {
   final bool isActive;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return PhotoTrailingWideTileCard(
-      activeGradient: context.colorTheme.toPwrGradient,
-      directusPhotoUrl: building.cover?.filename_disk,
-      title:
-          "${building.disableBuildingPrefix ? "" : "${context.localize.building_prefix} "}${building.name}",
-      subtitle: context.changeNull(building.addressFormatted),
-      isActive: isActive,
-      onTap: () {
-        unawaited(
-          ref.read(buildingsMapControllerProvider).onMarkerTap(building),
-        );
-      },
+    return Stack(
+      children: [
+        PhotoTrailingWideTileCard(
+          activeGradient: context.colorTheme.toPwrGradient,
+          directusPhotoUrl: building.cover?.filename_disk,
+          title:
+              "${building.disableBuildingPrefix ? "" : "${context.localize.building_prefix} "}${building.name}",
+          subtitle: context.changeNull(building.addressFormatted),
+          isActive: isActive,
+          onTap: () {
+            unawaited(
+              ref.read(buildingsMapControllerProvider).onMarkerTap(building),
+            );
+          },
+        ),
+        if (building.externalDigitalGuideMode != null &&
+            building.externalDigitalGuideIdOrURL != null)
+          Positioned(
+            top: 2,
+            right: WideTileCardConfig.imageSize,
+            child: IconButton(
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              icon: Icon(
+                Icons.info,
+                color: isActive
+                    ? context.colorTheme.whiteSoap
+                    : context.colorTheme.greyPigeon,
+              ),
+              onPressed: () {
+                unawaited(
+                  ref.navigateBuildingDetailAction(
+                    building.externalDigitalGuideMode!,
+                    building.externalDigitalGuideIdOrURL!,
+                  ),
+                );
+              },
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/features/buildings_view/building_tile.dart
+++ b/lib/features/buildings_view/building_tile.dart
@@ -53,12 +53,7 @@ class BuildingTile extends ConsumerWidget {
                     : context.colorTheme.greyPigeon,
               ),
               onPressed: () {
-                unawaited(
-                  ref.navigateBuildingDetailAction(
-                    building.externalDigitalGuideMode!,
-                    building.externalDigitalGuideIdOrURL!,
-                  ),
-                );
+                unawaited(ref.navigateBuildingDetailAction(building));
               },
             ),
           ),

--- a/lib/features/buildings_view/model/building_model.dart
+++ b/lib/features/buildings_view/model/building_model.dart
@@ -15,6 +15,8 @@ class BuildingModel extends Building implements GoogleNavigable {
           cover: building.cover,
           naturalName: building.naturalName,
           disableBuildingPrefix: building.disableBuildingPrefix,
+          externalDigitalGuideMode: building.externalDigitalGuideMode,
+          externalDigitalGuideIdOrURL: building.externalDigitalGuideIdOrURL,
         );
 
   @override

--- a/lib/features/buildings_view/repository/getBuildings.graphql
+++ b/lib/features/buildings_view/repository/getBuildings.graphql
@@ -10,5 +10,7 @@ query GetBuildings {
     }
     naturalName
     disableBuildingPrefix
+    externalDigitalGuideMode
+    externalDigitalGuideIdOrURL
   }
 }

--- a/lib/features/digital_guide_view/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide_view/presentation/digital_guide_view.dart
@@ -3,6 +3,7 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../../../api_base/directus_assets_url.dart";
 import "../../../config/ui_config.dart";
 import "../../../gen/assets.gen.dart";
 import "../../../utils/context_extensions.dart";
@@ -10,22 +11,22 @@ import "../../../utils/determine_contact_icon.dart";
 import "../../../widgets/detail_views/contact_section.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../widgets/my_error_widget.dart";
+import "../../../widgets/zoomable_images.dart";
 import "../data/models/digital_guide_response.dart";
 import "../data/repository/digital_guide_repository.dart";
 import "widgets/accessibility_button.dart";
 import "widgets/digital_guide_data_source_link.dart";
 import "widgets/digital_guide_features_section.dart";
-import "widgets/digital_guide_image.dart";
 import "widgets/headlines_section.dart";
 import "widgets/report_change_button.dart";
 
 @RoutePage()
 class DigitalGuideView extends ConsumerWidget {
   const DigitalGuideView({
-    @PathParam("id") required this.id,
+    @PathParam("id") required this.ourId,
   });
 
-  final int id;
+  final String ourId;
 
   static String localizedOfflineMessage(BuildContext context) {
     return context.localize.my_offline_error_message(
@@ -35,9 +36,10 @@ class DigitalGuideView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncDigitalGuideData = ref.watch(digitalGuideRepositoryProvider(id));
+    final asyncDigitalGuideData =
+        ref.watch(digitalGuideRepositoryProvider(ourId));
     return asyncDigitalGuideData.when(
-      data: _DigitalGuideView.new,
+      data: (data) => _DigitalGuideView(data.digitalGuideData, data.photoUrl),
       error: (error, stackTrace) => Scaffold(
         appBar: DetailViewAppBar(),
         body: MyErrorWidget(error),
@@ -54,9 +56,10 @@ class DigitalGuideView extends ConsumerWidget {
 }
 
 class _DigitalGuideView extends ConsumerWidget {
-  const _DigitalGuideView(this.digitalGuideData);
+  const _DigitalGuideView(this.digitalGuideData, this.photoUrl);
 
   final DigitalGuideResponse digitalGuideData;
+  final String? photoUrl;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -64,7 +67,7 @@ class _DigitalGuideView extends ConsumerWidget {
       const SizedBox(height: DigitalGuideConfig.heightSmall),
       SizedBox(
         height: DetailViewsConfig.imageHeight,
-        child: DigitalGuideImage(id: digitalGuideData.images[0]),
+        child: ZoomableOptimizedDirectusImage(photoUrl?.directusUrl),
       ),
       HeadlinesSection(
         name: digitalGuideData.translations.plTranslation.name,

--- a/lib/features/home_view/widgets/nav_actions_section.dart
+++ b/lib/features/home_view/widgets/nav_actions_section.dart
@@ -40,15 +40,6 @@ class NavActionsSection extends ConsumerWidget {
               ),
               ref.navigateAboutUs,
             ),
-            // _NavActionButton(
-            //   "Digital Guide",
-            //   Icon(
-            //     Icons.accessibility,
-            //     color: context.colorTheme.whiteSoap,
-            //     size: 32,
-            //   ),
-            //   () => unawaited(ref.navigateDigitalGuide(421)),
-            // ),
           ],
         ),
       );

--- a/lib/features/navigator/utils/navigation_commands.dart
+++ b/lib/features/navigator/utils/navigation_commands.dart
@@ -81,8 +81,8 @@ extension NavigationX on WidgetRef {
     await _router.push(const SksMenuRoute());
   }
 
-  Future<void> navigateDigitalGuide(int id) async {
-    await _router.push(DigitalGuideRoute(id: id));
+  Future<void> navigateDigitalGuide(String ourId) async {
+    await _router.push(DigitalGuideRoute(ourId: ourId));
   }
 
   Future<void> navigateAdaptedToiletDetails(AdaptedToilet adaptedToilet) async {
@@ -93,15 +93,15 @@ extension NavigationX on WidgetRef {
     await _router.push(DigitalGuideRoomDetailRoute(room: room));
   }
 
-  Future<void> navigateBuildingDetailAction(String mode, String urlOrID) async {
-    return switch (mode) {
-      "web_url" => launch(urlOrID),
-      "digital_guide_building" => navigateDigitalGuide(int.parse(urlOrID)),
+  Future<void> navigateBuildingDetailAction(BuildingModel building) async {
+    return switch (building.externalDigitalGuideMode) {
+      "web_url" => launch(building.externalDigitalGuideIdOrURL!),
+      "digital_guide_building" => navigateDigitalGuide(building.id),
       "digital_guide_other_place" => Logger().i(
           "Other Digital Guide place, not yet implemented",
         ),
       _ => Logger().w(
-          "Unknown externalDigitalGuideMode: $mode",
+          "Unknown externalDigitalGuideMode: ${building.externalDigitalGuideMode}",
         )
     };
   }

--- a/lib/features/navigator/utils/navigation_commands.dart
+++ b/lib/features/navigator/utils/navigation_commands.dart
@@ -1,7 +1,9 @@
 import "dart:async";
 
 import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:logger/logger.dart";
 
+import "../../../utils/launch_url_util.dart";
 import "../../buildings_view/model/building_model.dart";
 import "../../digital_guide_view/tabs/adapted_toilets/data/models/adapted_toilet.dart";
 import "../../digital_guide_view/tabs/rooms/data/models/digital_guide_room.dart";
@@ -89,5 +91,18 @@ extension NavigationX on WidgetRef {
 
   Future<void> navigateRoomDetails(DigitalGuideRoom room) async {
     await _router.push(DigitalGuideRoomDetailRoute(room: room));
+  }
+
+  Future<void> navigateBuildingDetailAction(String mode, String urlOrID) async {
+    return switch (mode) {
+      "web_url" => launch(urlOrID),
+      "digital_guide_building" => navigateDigitalGuide(int.parse(urlOrID)),
+      "digital_guide_other_place" => Logger().i(
+          "Other Digital Guide place, not yet implemented",
+        ),
+      _ => Logger().w(
+          "Unknown externalDigitalGuideMode: $mode",
+        )
+    };
   }
 }


### PR DESCRIPTION
1. connect digital guide to our building tiles with "i" icon
    - I allow to set manually id on the backend and the option if this is normal building, "other place" (different endpoint) or web url, cause why can't we set deeplink to sks menu or just url somewhere here too
2. I use OUR photos in the digital guide detail too, cause previously this could be confusing that the photo was different on the list and in the detail

I only added few for testing for now, @odominiak will insert rest soon

![Zrzut ekranu 2025-01-17 o 00 24 28](https://github.com/user-attachments/assets/001badf0-e5af-42e4-ba8c-97cea318e705)
![Zrzut ekranu 2025-01-17 o 00 29 54](https://github.com/user-attachments/assets/113e6908-cba8-4a51-be07-2bd5d8282007)
![Zrzut ekranu 2025-01-17 o 00 30 09](https://github.com/user-attachments/assets/00ee3220-8cb3-4eb1-b167-57fd0e9fb7b8)

