### PR TITLE
Add dressing rooms to digital guide

### DIFF
--- a/lib/features/digital_guide_view/presentation/widgets/digital_guide_features_section.dart
+++ b/lib/features/digital_guide_view/presentation/widgets/digital_guide_features_section.dart
@@ -9,6 +9,7 @@ import "../../data/models/level_with_regions.dart";
 import "../../data/repository/levels_repository.dart";
 import "../../tabs/adapted_toilets/presentation/adapted_toilets_expansion_tile_content.dart";
 import "../../tabs/amenities/presentation/amenities_expansion_tile_content.dart";
+import "../../tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart";
 import "../../tabs/evacuation/evacuation_widget.dart";
 import "../../tabs/localization/presentation/localization_expansion_tile_content.dart";
 import "../../tabs/lodge/presentation/digital_guide_lodge_expansion_tile_content.dart";
@@ -107,6 +108,14 @@ class DigitalGuideFeaturesSection extends ConsumerWidget {
         title: context.localize.lodge,
         content: [
           DigitalGuideLodgeExpansionTileContent(
+            digitalGuideData,
+          ),
+        ],
+      ),
+      (
+        title: context.localize.dressing_room,
+        content: [
+          DigitalGuideDressingRoomsExpansionTileContent(
             digitalGuideData,
           ),
         ],

--- a/lib/features/digital_guide_view/readme.md
+++ b/lib/features/digital_guide_view/readme.md
@@ -28,3 +28,6 @@
 5) Lodges data
   * /lodges/?building={buildingId}
 
+6) Dressing rooms data
+  * /dressing_rooms/?building={buildingId}
+

--- a/lib/features/digital_guide_view/tabs/dressing_room/data/models/digital_guide_dressing_room.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/data/models/digital_guide_dressing_room.dart
@@ -1,0 +1,42 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "digital_guide_dressing_room.freezed.dart";
+part "digital_guide_dressing_room.g.dart";
+
+@freezed
+class DigitalGuideDressingRoom with _$DigitalGuideDressingRoom {
+  const factory DigitalGuideDressingRoom({
+    required int id,
+    required DigitalGuideTranslationsDressingRoom translations,
+    @JsonKey(name: "images") required List<int>? imagesIds,
+  }) = _DigitalGuideDressingRoom;
+
+  factory DigitalGuideDressingRoom.fromJson(Map<String, dynamic> json) =>
+      _$DigitalGuideDressingRoomFromJson(json);
+}
+
+@freezed
+class DigitalGuideTranslationsDressingRoom
+    with _$DigitalGuideTranslationsDressingRoom {
+  const factory DigitalGuideTranslationsDressingRoom({
+    required DigitalGuideTranslationDressingRoom pl,
+  }) = _DigitalGuideTranslationsDressingRoom;
+
+  factory DigitalGuideTranslationsDressingRoom.fromJson(
+          Map<String, dynamic> json,) =>
+      _$DigitalGuideTranslationsDressingRoomFromJson(json);
+}
+
+@freezed
+class DigitalGuideTranslationDressingRoom
+    with _$DigitalGuideTranslationDressingRoom {
+  @JsonSerializable(fieldRename: FieldRename.snake)
+  const factory DigitalGuideTranslationDressingRoom({
+    required String location,
+    required String workingDaysAndHours,
+    required String comment,
+  }) = _DigitalGuideTranslationDressingRoom;
+  factory DigitalGuideTranslationDressingRoom.fromJson(
+          Map<String, dynamic> json,) =>
+      _$DigitalGuideTranslationDressingRoomFromJson(json);
+}

--- a/lib/features/digital_guide_view/tabs/dressing_room/data/models/digital_guide_dressing_room.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/data/models/digital_guide_dressing_room.dart
@@ -23,7 +23,8 @@ class DigitalGuideTranslationsDressingRoom
   }) = _DigitalGuideTranslationsDressingRoom;
 
   factory DigitalGuideTranslationsDressingRoom.fromJson(
-          Map<String, dynamic> json,) =>
+    Map<String, dynamic> json,
+  ) =>
       _$DigitalGuideTranslationsDressingRoomFromJson(json);
 }
 
@@ -37,6 +38,7 @@ class DigitalGuideTranslationDressingRoom
     required String comment,
   }) = _DigitalGuideTranslationDressingRoom;
   factory DigitalGuideTranslationDressingRoom.fromJson(
-          Map<String, dynamic> json,) =>
+    Map<String, dynamic> json,
+  ) =>
       _$DigitalGuideTranslationDressingRoomFromJson(json);
 }

--- a/lib/features/digital_guide_view/tabs/dressing_room/data/repository/dressing_rooms_repository.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/data/repository/dressing_rooms_repository.dart
@@ -1,0 +1,25 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../../../data/api/digital_guide_get_and_cache.dart";
+import "../../../../data/models/digital_guide_response.dart";
+import "../models/digital_guide_dressing_room.dart";
+
+part "dressing_rooms_repository.g.dart";
+
+@riverpod
+Future<IList<DigitalGuideDressingRoom>> dressingRoomsRepository(
+  Ref ref,
+  DigitalGuideResponse building,
+) async {
+  final endpoint = "dressing_rooms/?building=${building.id}";
+  return ref.getAndCacheDataFromDigitalGuide(
+    endpoint,
+    (List<dynamic> json) => json
+        .whereType<Map<String, dynamic>>()
+        .map(DigitalGuideDressingRoom.fromJson)
+        .toIList(),
+    onRetry: () => ref.invalidateSelf(),
+  );
+}

--- a/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
@@ -48,7 +48,7 @@ class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
         child: Text(context.localize.no_dressing_room_in_the_building),
       );
     }
-    final lodgeInformation = dressingRoom!.translations.pl;
+    final dressingRoomInformation = dressingRoom!.translations.pl;
     return Padding(
       padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),
       child: Column(
@@ -59,17 +59,21 @@ class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
             padding: const EdgeInsets.symmetric(
               vertical: DigitalGuideConfig.heightSmall,
             ),
-            child: Text(lodgeInformation.location),
+            child: Text(dressingRoomInformation.location),
           ),
-          Text(context.localize.working_hours, style: context.textTheme.title),
-          const SizedBox(
-            height: DigitalGuideConfig.heightSmall,
-          ),
-          Text(lodgeInformation.workingDaysAndHours),
-          const SizedBox(
-            height: DigitalGuideConfig.heightSmall,
-          ),
-          if (lodgeInformation.comment.isNotEmpty)
+          if (dressingRoomInformation.workingDaysAndHours.isNotEmpty)
+            Text(
+              context.localize.working_hours,
+              style: context.textTheme.title,
+            ),
+          if (dressingRoomInformation.workingDaysAndHours.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: DigitalGuideConfig.heightSmall,
+              ),
+              child: Text(dressingRoomInformation.workingDaysAndHours),
+            ),
+          if (dressingRoomInformation.comment.isNotEmpty)
             Padding(
               padding: const EdgeInsets.only(
                 bottom: DigitalGuideConfig.paddingSmall,
@@ -79,8 +83,8 @@ class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
                 style: context.textTheme.title,
               ),
             ),
-          Text(lodgeInformation.comment),
-          if (lodgeInformation.comment.isNotEmpty)
+          Text(dressingRoomInformation.comment),
+          if (dressingRoomInformation.comment.isNotEmpty)
             const SizedBox(
               height: DigitalGuideConfig.heightMedium,
             ),

--- a/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
@@ -1,0 +1,92 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../../../../config/ui_config.dart";
+import "../../../../../theme/app_theme.dart";
+import "../../../../../utils/context_extensions.dart";
+import "../../../../../widgets/my_error_widget.dart";
+import "../../../data/models/digital_guide_response.dart";
+import "../../../presentation/widgets/digital_guide_photo_row.dart";
+import "../data/models/digital_guide_dressing_room.dart";
+import "../data/repository/dressing_rooms_repository.dart";
+
+class DigitalGuideDressingRoomsExpansionTileContent extends ConsumerWidget {
+  const DigitalGuideDressingRoomsExpansionTileContent(
+      this.digitalGuideResponse,);
+
+  final DigitalGuideResponse digitalGuideResponse;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dressingRoomsResponse =
+        ref.watch(dressingRoomsRepositoryProvider(digitalGuideResponse));
+    return dressingRoomsResponse.when(
+      data: (data) => _DigitalGuideDressingRoomsExpansionTileContent(
+          dressingRoom: data.firstOrNull,),
+      error: (error, _) => MyErrorWidget(error),
+      loading: () => const Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}
+
+class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
+  final DigitalGuideDressingRoom? dressingRoom;
+
+  const _DigitalGuideDressingRoomsExpansionTileContent({
+    required this.dressingRoom,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (dressingRoom == null) {
+      return Center(
+          child: Text(context.localize.no_dressing_room_in_the_building),);
+    }
+    final lodgeInformation = dressingRoom!.translations.pl;
+    return Padding(
+      padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(context.localize.localization, style: context.textTheme.title),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: DigitalGuideConfig.heightSmall,
+            ),
+            child: Text(lodgeInformation.location),
+          ),
+          Text(context.localize.working_hours, style: context.textTheme.title),
+          const SizedBox(
+            height: DigitalGuideConfig.heightSmall,
+          ),
+          Text(lodgeInformation.workingDaysAndHours),
+          const SizedBox(
+            height: DigitalGuideConfig.heightSmall,
+          ),
+          if (lodgeInformation.comment.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(
+                bottom: DigitalGuideConfig.paddingSmall,
+              ),
+              child: Text(
+                context.localize.additional_information,
+                style: context.textTheme.title,
+              ),
+            ),
+          Text(lodgeInformation.comment),
+          if (lodgeInformation.comment.isNotEmpty)
+            const SizedBox(
+              height: DigitalGuideConfig.heightMedium,
+            ),
+          DigitalGuidePhotoRow(
+            imagesIDs:
+                dressingRoom!.imagesIds?.toIList() ?? const IList.empty(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
+++ b/lib/features/digital_guide_view/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
@@ -13,7 +13,8 @@ import "../data/repository/dressing_rooms_repository.dart";
 
 class DigitalGuideDressingRoomsExpansionTileContent extends ConsumerWidget {
   const DigitalGuideDressingRoomsExpansionTileContent(
-      this.digitalGuideResponse,);
+    this.digitalGuideResponse,
+  );
 
   final DigitalGuideResponse digitalGuideResponse;
 
@@ -23,7 +24,8 @@ class DigitalGuideDressingRoomsExpansionTileContent extends ConsumerWidget {
         ref.watch(dressingRoomsRepositoryProvider(digitalGuideResponse));
     return dressingRoomsResponse.when(
       data: (data) => _DigitalGuideDressingRoomsExpansionTileContent(
-          dressingRoom: data.firstOrNull,),
+        dressingRoom: data.firstOrNull,
+      ),
       error: (error, _) => MyErrorWidget(error),
       loading: () => const Center(
         child: CircularProgressIndicator(),
@@ -43,7 +45,8 @@ class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
   Widget build(BuildContext context) {
     if (dressingRoom == null) {
       return Center(
-          child: Text(context.localize.no_dressing_room_in_the_building),);
+        child: Text(context.localize.no_dressing_room_in_the_building),
+      );
     }
     final lodgeInformation = dressingRoom!.translations.pl;
     return Padding(

--- a/lib/features/digital_guide_view/tabs/lodge/presentation/digital_guide_lodge_expansion_tile_content.dart
+++ b/lib/features/digital_guide_view/tabs/lodge/presentation/digital_guide_lodge_expansion_tile_content.dart
@@ -56,14 +56,18 @@ class _DigitalGuideLodgeExpansionTileContent extends StatelessWidget {
             ),
             child: Text(lodgeInformation.location),
           ),
-          Text(context.localize.working_hours, style: context.textTheme.title),
-          const SizedBox(
-            height: DigitalGuideConfig.heightSmall,
-          ),
-          Text(lodgeInformation.workingDaysAndHours),
-          const SizedBox(
-            height: DigitalGuideConfig.heightSmall,
-          ),
+          if (lodgeInformation.workingDaysAndHours.isNotEmpty)
+            Text(
+              context.localize.working_hours,
+              style: context.textTheme.title,
+            ),
+          if (lodgeInformation.workingDaysAndHours.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: DigitalGuideConfig.heightSmall,
+              ),
+              child: Text(lodgeInformation.workingDaysAndHours),
+            ),
           if (lodgeInformation.comment.isNotEmpty)
             Padding(
               padding: const EdgeInsets.only(

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -301,5 +301,7 @@
   "you_can_adjust": "Możesz dostosować informacje pod swoje specjalne potrzeby",
   "additional_information": "Dodatkowe informacje",
   "lodge": "Portiernia",
-  "no_lodge_in_the_building": "W tym budynku nie ma portierni"
+  "dressing_room": "Szatnia",
+  "no_lodge_in_the_building": "W tym budynku nie ma portierni",
+  "no_dressing_room_in_the_building": "W tym budynku nie ma szatni"
 }


### PR DESCRIPTION
#541 

- 1:1 changes as with lodges (I also changed working hours to be displayed only when information's available)
- I was thinking for a moment whether to create single UI that'd handle lodges and dressing rooms but finally decided just to copy and adjust existing solution. Imo digital guide structure is complicated, there's no point in complicating it even more, minor code repetition is not a sin in this scenario I believe 😆 But let me know WDYT 

<img src="https://github.com/user-attachments/assets/10cd0288-a00f-44a8-bb1c-2a5bdd621d61" height="500" />


