### PR TITLE
bug: Sks menu button fix

### DIFF
--- a/lib/features/sks_menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks_menu/presentation/sks_menu_screen.dart
@@ -142,7 +142,7 @@ class _SKSMenuUnavailableAnimation extends HookWidget {
         ) *
         0.6;
 
-    const animationTopOffset = -0.2;
+    const animationTopOffset = -0.1;
 
     return HorizontalSymmetricSafeAreaScaffold(
       backgroundColor: context.colorTheme.whiteSoap,
@@ -159,11 +159,11 @@ class _SKSMenuUnavailableAnimation extends HookWidget {
             child: Align(
               alignment: const Alignment(0, -0.2),
               child: SingleChildScrollView(
-                child: Column(
-                  children: [
-                    Transform.translate(
-                      offset: Offset(0, animationTopOffset * animationSize),
-                      child: SizedBox.square(
+                child: Transform.translate(
+                  offset: Offset(0, animationTopOffset * animationSize),
+                  child: Column(
+                    children: [
+                      SizedBox.square(
                         dimension: animationSize,
                         child: Lottie.asset(
                           Assets.animations.sksClosed,
@@ -174,50 +174,45 @@ class _SKSMenuUnavailableAnimation extends HookWidget {
                           renderCache: RenderCache.drawingCommands,
                           onLoaded: (composition) {
                             final totalDuration = composition.duration;
-                            Future.delayed(
-                                totalDuration *
-                                    0.8, // in my opinion the animation is a bit boring at the end, so we can show the texts a bit earlier
-                                () {
+                            Future.delayed(totalDuration * 0.8, () {
                               isAnimationCompleted.value = true;
                             });
                           },
                         ),
                       ),
-                    ),
-                    Opacity(
-                      opacity: isAnimationCompleted.value ? 1 : 0,
-                      child: Transform.translate(
-                        offset: Offset(
-                          0,
-                          animationSize *
-                              (-0.1 +
-                                  animationTopOffset), // the animation has some extra space at the bottom
-                        ),
-                        child: Column(
-                          children: [
-                            Text(
-                              context.localize.sks_menu_closed,
-                              style: context.textTheme.headline.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                            if (onShowLastMenuTap != null)
-                              Padding(
-                                padding: const EdgeInsets.only(top: 12),
-                                child: MyTextButton(
-                                  actionTitle:
-                                      context.localize.sks_show_last_menu,
-                                  onClick: onShowLastMenuTap,
-                                  showBorder: true,
-                                  color: context.colorTheme.blueAzure,
+                      Opacity(
+                        opacity: isAnimationCompleted.value ? 1 : 0,
+                        child: Transform.translate(
+                          offset: Offset(
+                            0,
+                            -(animationSize * 0.1),
+                          ),
+                          child: Column(
+                            children: [
+                              Text(
+                                context.localize.sks_menu_closed,
+                                style: context.textTheme.headline.copyWith(
+                                  fontWeight: FontWeight.bold,
                                 ),
+                                textAlign: TextAlign.center,
                               ),
-                          ],
+                              if (onShowLastMenuTap != null)
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 12),
+                                  child: MyTextButton(
+                                    actionTitle:
+                                        context.localize.sks_show_last_menu,
+                                    onClick: onShowLastMenuTap,
+                                    showBorder: true,
+                                    color: context.colorTheme.blueAzure,
+                                  ),
+                                ),
+                            ],
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixed that unclickable button issue. The problem was that"Pokaż ostatnio dostępne menu" button was under the image, but i managed to make it clickable and I just moved the whole section up. This is the outcome:
![image](https://github.com/user-attachments/assets/28726a5b-80c4-439f-9dcc-2c098977cde6)
![image](https://github.com/user-attachments/assets/5c276712-19fc-415f-a9be-b0754bd24a7a)
![image](https://github.com/user-attachments/assets/f0a2045a-8c9a-4686-9745-289a65f35f4e)


And without the button, if the latest menu is not available:
![image](https://github.com/user-attachments/assets/889be367-3a8a-4af8-bfa1-67b24089865b)
![image](https://github.com/user-attachments/assets/3b0e10e8-a8ca-41de-8679-bbcdb8302aa2)
![image](https://github.com/user-attachments/assets/df2a9d08-fb2e-410b-a084-fe391eba38ee)
