### PR TITLE
Chart height on tablets

### DIFF
--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart.dart
@@ -24,88 +24,88 @@ class SksChart extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(right: SksChartConfig.paddingLarge),
-      child: AspectRatio(
-        aspectRatio: 1.5,
-        child: LineChart(
-          duration: Duration.zero,
-          LineChartData(
-            clipData: const FlClipData.all(),
-            backgroundColor: context.colorTheme.whiteSoap,
-            gridData: SksChartGridData(context, maxNumberOfUsers / 5),
-            maxY: maxNumberOfUsers + (maxNumberOfUsers / 10).toInt(),
-            lineBarsData: [
-              LineChartBarData(
-                belowBarData: BarAreaData(
-                  show: true,
-                  gradient: ColorsConsts.toPwrGradient,
-                  applyCutOffY: true,
-                ),
-                isCurved: true,
-                color: context.colorTheme.orangePomegranade,
-                dotData: FlDotData(
-                  checkToShowDot: (FlSpot spot, LineChartBarData barData) {
-                    return false;
-                  },
-                ),
-                spots: chartData.asMap().entries.map<FlSpot>((e) {
-                  if (e.value.externalTimestamp.isAfter(DateTime.now())) {
-                    return FlSpot.nullSpot;
-                  } else {
-                    return FlSpot(
-                      e.key.toDouble(),
-                      e.value.activeUsers.toDouble(),
-                    );
-                  }
-                }).toList(),
+      // child: AspectRatio(
+      //   aspectRatio: 1.5,
+      child: LineChart(
+        duration: Duration.zero,
+        LineChartData(
+          clipData: const FlClipData.all(),
+          backgroundColor: context.colorTheme.whiteSoap,
+          gridData: SksChartGridData(context, maxNumberOfUsers / 5),
+          maxY: maxNumberOfUsers + (maxNumberOfUsers / 10).toInt(),
+          lineBarsData: [
+            LineChartBarData(
+              belowBarData: BarAreaData(
+                show: true,
+                gradient: ColorsConsts.toPwrGradient,
+                applyCutOffY: true,
               ),
-              LineChartBarData(
-                isCurved: true,
-                dashArray: [
-                  SksChartConfig.borderDashArray.toInt(),
-                  SksChartConfig.borderDashArray.toInt(),
-                ],
-                dotData: FlDotData(
-                  checkToShowDot: (FlSpot spot, LineChartBarData barData) {
-                    return false;
-                  },
-                ),
-                barWidth: 1.25,
-                color: context.colorTheme.blueAzure,
-                spots: chartData.asMap().entries.map<FlSpot>((e) {
+              isCurved: true,
+              color: context.colorTheme.orangePomegranade,
+              dotData: FlDotData(
+                checkToShowDot: (FlSpot spot, LineChartBarData barData) {
+                  return false;
+                },
+              ),
+              spots: chartData.asMap().entries.map<FlSpot>((e) {
+                if (e.value.externalTimestamp.isAfter(DateTime.now())) {
+                  return FlSpot.nullSpot;
+                } else {
                   return FlSpot(
                     e.key.toDouble(),
-                    e.value.movingAverage21.toDouble(),
+                    e.value.activeUsers.toDouble(),
                   );
-                }).toList(),
-              ),
-              // this is the biggest hack you'll ever see in your life
-              // this is transparent data const = 0 that allows the chart to have a hour tooltip
-              LineChartBarData(
-                color: Colors.transparent,
-                spots: chartData.asMap().entries.map<FlSpot>((e) {
-                  return FlSpot(
-                    e.key.toDouble(),
-                    0,
-                  );
-                }).toList(),
-              ),
-            ],
-            titlesData: FlTitlesData(
-              topTitles: const HideLabels(),
-              rightTitles: const HideLabels(),
-              leftTitles: SksChartRightTiles(context),
-              bottomTitles: SksChartBottomTitles(
-                context,
-                chartData,
-              ),
+                }
+              }).toList(),
             ),
-            lineTouchData: SksChartLineTouchData(
+            LineChartBarData(
+              isCurved: true,
+              dashArray: [
+                SksChartConfig.borderDashArray.toInt(),
+                SksChartConfig.borderDashArray.toInt(),
+              ],
+              dotData: FlDotData(
+                checkToShowDot: (FlSpot spot, LineChartBarData barData) {
+                  return false;
+                },
+              ),
+              barWidth: 1.25,
+              color: context.colorTheme.blueAzure,
+              spots: chartData.asMap().entries.map<FlSpot>((e) {
+                return FlSpot(
+                  e.key.toDouble(),
+                  e.value.movingAverage21.toDouble(),
+                );
+              }).toList(),
+            ),
+            // this is the biggest hack you'll ever see in your life
+            // this is transparent data const = 0 that allows the chart to have a hour tooltip
+            LineChartBarData(
+              color: Colors.transparent,
+              spots: chartData.asMap().entries.map<FlSpot>((e) {
+                return FlSpot(
+                  e.key.toDouble(),
+                  0,
+                );
+              }).toList(),
+            ),
+          ],
+          titlesData: FlTitlesData(
+            topTitles: const HideLabels(),
+            rightTitles: const HideLabels(),
+            leftTitles: SksChartRightTiles(context),
+            bottomTitles: SksChartBottomTitles(
               context,
-              chartData.map((e) => e.externalTimestamp).toIList(),
+              chartData,
             ),
+          ),
+          lineTouchData: SksChartLineTouchData(
+            context,
+            chartData.map((e) => e.externalTimestamp).toIList(),
           ),
         ),
       ),
+      // ),
     );
   }
 }

--- a/lib/features/sks/sks_chart/presentation/sks_chart_card.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_card.dart
@@ -15,11 +15,13 @@ class SksChartCard extends StatelessWidget {
     required this.currentNumberOfUsers,
     required this.maxNumberOfUsers,
     required this.chartData,
+    required this.height,
   });
 
   final SksUserData? currentNumberOfUsers;
   final double maxNumberOfUsers;
   final IList<SksChartData> chartData;
+  final double height;
 
   @override
   Widget build(BuildContext context) {
@@ -42,9 +44,12 @@ class SksChartCard extends StatelessWidget {
             const SizedBox(
               height: SksChartConfig.heightLarge,
             ),
-            SksChart(
-              maxNumberOfUsers: maxNumberOfUsers,
-              chartData: chartData,
+            SizedBox(
+              height: 0.5 * height,
+              child: SksChart(
+                maxNumberOfUsers: maxNumberOfUsers,
+                chartData: chartData,
+              ),
             ),
             const Padding(
               padding: EdgeInsets.only(

--- a/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
@@ -61,6 +61,7 @@ class SksChartSheet extends ConsumerWidget {
                           maxNumberOfUsers: maxNumberOfUsers,
                           chartData:
                               asyncChartData.value ?? const IList.empty(),
+                          height: sheetHeight,
                         ),
                       ),
                       Padding(

--- a/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
@@ -50,7 +50,7 @@ class SksChartSheet extends ConsumerWidget {
                 ),
                 Expanded(
                   child: ListView(
-                    physics: const NeverScrollableScrollPhysics(),
+                    physics: const BouncingScrollPhysics(),
                     children: [
                       Padding(
                         padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
Let me know if it can be kind of hardocoded like this. I tried fixing it better a long time and I failed. If I have to do it in an elegant way, it's gonna be painful.... @simon-the-shark @mikolaj-jalocha @tomasz-trela 

# Before
![image](https://github.com/user-attachments/assets/ec9a5d05-3dbc-47c0-bc22-868116223666)

# After
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/5275ef91-a55d-4d8c-a06d-3e76dedc4e5c" />
<img width="332" alt="image" src="https://github.com/user-attachments/assets/862d762c-01d5-4c9d-accc-56253b655581" />



# l10n.yaml examplanation - without synthetic-package: false - doesn't generate l10n files without it
<img width="985" alt="image" src="https://github.com/user-attachments/assets/f64e1096-4fe0-458e-8e74-ff83997a85a1" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust chart height for tablets by removing `AspectRatio` and adding dynamic height control in `SksChartCard`.
> 
>   - **Behavior**:
>     - Removed `AspectRatio` from `SksChart` in `sks_chart.dart` to allow dynamic height adjustment.
>     - Added `height` parameter to `SksChartCard` in `sks_chart_card.dart` to control chart height.
>     - Updated `SksChartSheet` in `sks_chart_sheet.dart` to pass `sheetHeight` to `SksChartCard`.
>   - **Misc**:
>     - Changed `physics` in `SksChartSheet` from `NeverScrollableScrollPhysics` to `BouncingScrollPhysics`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 5c73240ee8f085309b5d6cf4095f2923398396fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->