### PR TITLE
Android google play deploy

### DIFF
--- a/.github/workflows/android_beta_upload.yml
+++ b/.github/workflows/android_beta_upload.yml
@@ -1,0 +1,48 @@
+name: Deploy beta app on android to google play
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        
+      - name: Copy ENV_FILE to .env
+        run: echo "${{ secrets.ENV_FILE }}" > .env
+       
+      - name: Place Key Properties
+        run: echo "${{ secrets.KEY_PROPERTIES }}" > android/key.properties
+
+      - name: Decode and place Keystore
+        run: echo "${{ secrets.STORE_FILE_JKS_B64 }}" | base64 -d > android/app/storeFile.jks
+
+      - name: Decode and place TOPWR Key JSON
+        run: echo "${{ secrets.SERVICE_ACCOUNT_KEY_JSON_B64 }}" | base64 -d > android/service-acount-key.json
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version-file: pubspec.yaml
+
+      - run: flutter --version
+      - run: flutter config --explicit-package-dependencies
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Setup localizations
+        run: flutter gen-l10n
+
+      - name: Generate files
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Fetch metadata, latest build version and deploy beta with Fastlane
+        run: |
+          cd android
+          fastlane supply init
+          fastlane beta

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("service-acount-key.json")
+package_name("com.solvro.topwr")

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,0 +1,30 @@
+default_platform(:android)
+
+json_key_file = "service-acount-key.json"
+topwr_package_name = "com.solvro.topwr"
+
+platform :android do
+
+  desc "Deploy the beta (for testers) version to Google Play"
+  lane :beta do
+	build_number = google_play_track_version_codes(
+      package_name: topwr_package_name,
+      track: "beta",
+      json_key: json_key_file
+    ).first.to_i
+  
+    sh "flutter clean"
+    sh "flutter build appbundle --release --build-number=#{build_number+1}"
+    upload_to_play_store(
+      track: "beta",
+	  json_key: json_key_file,
+      aab: "../build/app/outputs/bundle/release/app-release.aab",
+      skip_upload_apk: true,
+      skip_upload_changelogs: true,
+	  skip_upload_metadata: true,
+	  skip_upload_images: true,
+	  skip_upload_screenshots: true,
+	  validate_only: true
+    )
+  end
+end


### PR DESCRIPTION
The GitHub action script builds the repo code and deploys app on google play for the beta testers. 
It can be run manually from the actions tab on GitHub.
Info how to setup GitHub action secrets, has been sent to @simon-the-shark

There is one more thing, we could store android metadata with photos, descriptions, etc. on GitHub.
Fastlane can pick it up and send those to google play automatically. For now, it is skipped in Fastlane file, because I only managed to do it once, and then it broke XD. 
And I genuinely don't know how to fix this error and google play API doesn't help troubleshooting that, so it may take me a while. But maybe we don't need it considering, that the file layout is different for iOS. WDYT?