### PR TITLE
fix: use `flutter_map_location_marker` from github - temporarly

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -96,7 +96,11 @@ dependencies:
   #Maps
   flutter_map: ^8.1.0
   flutter_map_cancellable_tile_provider: ^3.1.0
-  flutter_map_location_marker: ^9.1.1
+  flutter_map_location_marker: # TODO: upgrade when they release a new version
+    git:
+      url: https://github.com/tlserver/flutter_map_location_marker
+      ref: 3c8bfd4
+
   flutter_map_compass: ^1.1.1
   flutter_map_cache: ^1.5.2
   flutter_map_animations: ^0.9.0
@@ -151,7 +155,6 @@ dev_dependencies:
   test: ^1.25.15
 
 dependency_overrides:
-  flutter_map: ^8.1.0
   source_gen: ^2.0.0
   intl: ^0.20.2
   theme_tailor_annotation: # remove this when idiots push a release


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `flutter_map_location_marker` to a specific GitHub commit and remove `flutter_map` override in `pubspec.yaml`.
> 
>   - **Dependencies**:
>     - Change `flutter_map_location_marker` to use a specific GitHub commit instead of version `^9.1.1` in `pubspec.yaml`.
>     - Remove `flutter_map` from `dependency_overrides` in `pubspec.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for f77534d72887fa0485c8fdfcd70c467900ae14a3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->