### PR TITLE
fix: parking chart hours overlap

### DIFF
--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -10,10 +10,17 @@ class BottomLabels extends AxisTitles {
         sideTitles: SideTitles(
           showTitles: true,
           interval: 1,
+          reservedSize: 48,
           getTitlesWidget:
-              (double val, _) => SideTitleWidget(
-                axisSide: AxisSide.bottom,
-                child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
+              (double val, _) => Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Transform.rotate(
+                  angle: -45 / 180 * 3.1415926535,
+                  child: SideTitleWidget(
+                    axisSide: AxisSide.bottom,
+                    child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
+                  ),
+                ),
               ),
         ),
       );

--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -1,13 +1,11 @@
-import "dart:math";
-
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/widgets.dart";
 
 import "../../../../theme/app_theme.dart";
+import "../../../../utils/angles.dart";
 import "../utils/chart_utils.dart";
 
-const int rotationAngle = -45;
-const int degreesToRadiansFactor = 180;
+const double rotationAngle = -45;
 
 class BottomLabels extends AxisTitles {
   BottomLabels(BuildContext context)
@@ -20,7 +18,7 @@ class BottomLabels extends AxisTitles {
               (double val, _) => Padding(
                 padding: const EdgeInsets.only(top: 4),
                 child: Transform.rotate(
-                  angle: rotationAngle / degreesToRadiansFactor * pi,
+                  angle: rotationAngle.radians,
                   child: SideTitleWidget(
                     axisSide: AxisSide.bottom,
                     child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),

--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -4,6 +4,10 @@ import "package:flutter/widgets.dart";
 import "../../../../theme/app_theme.dart";
 import "../utils/chart_utils.dart";
 
+const int rotationAngle = -45;
+const double pi = 3.141592653;
+const int degreesToRadiansFactor = 180;
+
 class BottomLabels extends AxisTitles {
   BottomLabels(BuildContext context)
     : super(
@@ -15,7 +19,7 @@ class BottomLabels extends AxisTitles {
               (double val, _) => Padding(
                 padding: const EdgeInsets.only(top: 4),
                 child: Transform.rotate(
-                  angle: -45 / 180 * 3.1415926535,
+                  angle: rotationAngle / degreesToRadiansFactor * pi,
                   child: SideTitleWidget(
                     axisSide: AxisSide.bottom,
                     child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),

--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -1,3 +1,5 @@
+import "dart:math";
+
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/widgets.dart";
 
@@ -5,7 +7,6 @@ import "../../../../theme/app_theme.dart";
 import "../utils/chart_utils.dart";
 
 const int rotationAngle = -45;
-const double pi = 3.141592653;
 const int degreesToRadiansFactor = 180;
 
 class BottomLabels extends AxisTitles {

--- a/lib/utils/angles.dart
+++ b/lib/utils/angles.dart
@@ -1,0 +1,5 @@
+import "dart:math";
+
+extension DoubleX on double {
+  double get radians => this * (pi / 180);
+}


### PR DESCRIPTION
I've been trying to play with the 'interval' field but it was simply painful so I figured out a rotation that should provide more space for labels to spread across the axis. In my opinion, it looks decent. Let me know what you think :D

<img width="717" alt="image" src="https://github.com/user-attachments/assets/5fd1620d-b317-4ea4-9851-17ca58a16aed" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Rotate bottom labels by -45 degrees in `BottomLabels` to prevent overlap, using a new radians conversion utility.
> 
>   - **Behavior**:
>     - Rotates bottom labels by -45 degrees in `BottomLabels` in `labels_bottom.dart` to prevent overlap.
>     - Sets `reservedSize` to 48 for better spacing.
>   - **Utilities**:
>     - Adds `DoubleX` extension in `angles.dart` to convert degrees to radians.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 156b10efe6ed6ec4975c7ee5086a5160256da878. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->