### PR TITLE
refactor: move accesibility managers to business layer in structure tab

### DIFF
--- a/lib/features/digital_guide/tabs/structure/business/railings_accessibility_comments_manager.dart
+++ b/lib/features/digital_guide/tabs/structure/business/railings_accessibility_comments_manager.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
-import "../../../../../../l10n/app_localizations.dart";
-import "../../../../business/accessibility_comments_manager.dart";
-import "../models/railing.dart";
+import "../../../../../l10n/app_localizations.dart";
+import "../../../business/accessibility_comments_manager.dart";
+import "../data/models/railing.dart";
 
 class RailingsAccessibilityCommentsManager extends AccessibilityCommentsManager {
   RailingsAccessibilityCommentsManager({required this.railing, required this.l10n});

--- a/lib/features/digital_guide/tabs/structure/business/ramps_accessibility_comments_manager.dart
+++ b/lib/features/digital_guide/tabs/structure/business/ramps_accessibility_comments_manager.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
-import "../../../../../../l10n/app_localizations.dart";
-import "../../../../business/accessibility_comments_manager.dart";
-import "../models/ramp.dart";
+import "../../../../../l10n/app_localizations.dart";
+import "../../../business/accessibility_comments_manager.dart";
+import "../data/models/ramp.dart";
 
 class RampsAccessibilityCommentsManager extends AccessibilityCommentsManager {
   RampsAccessibilityCommentsManager({required this.ramps, required this.l10n});

--- a/lib/features/digital_guide/tabs/structure/business/stairs_accessibility_comments_manager.dart
+++ b/lib/features/digital_guide/tabs/structure/business/stairs_accessibility_comments_manager.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
-import "../../../../../../l10n/app_localizations.dart";
-import "../../../../business/accessibility_comments_manager.dart";
-import "../models/stairs.dart";
+import "../../../../../l10n/app_localizations.dart";
+import "../../../business/accessibility_comments_manager.dart";
+import "../data/models/stairs.dart";
 
 class StairsAccessibilityCommentsManager extends AccessibilityCommentsManager {
   StairsAccessibilityCommentsManager({required this.stairs, required this.l10n});

--- a/lib/features/digital_guide/tabs/structure/business/stairway_accessibility_comments_manager.dart
+++ b/lib/features/digital_guide/tabs/structure/business/stairway_accessibility_comments_manager.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
-import "../../../../../../l10n/app_localizations.dart";
-import "../../../../business/accessibility_comments_manager.dart";
-import "../models/stairway.dart";
+import "../../../../../l10n/app_localizations.dart";
+import "../../../business/accessibility_comments_manager.dart";
+import "../data/models/stairway.dart";
 
 class StairwayAccessibilityCommentsManager extends AccessibilityCommentsManager {
   StairwayAccessibilityCommentsManager({required this.stairway, required this.l10n});

--- a/lib/features/digital_guide/tabs/structure/business/toilets_accessibility_comments_manager.dart
+++ b/lib/features/digital_guide/tabs/structure/business/toilets_accessibility_comments_manager.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
-import "../../../../../../l10n/app_localizations.dart";
-import "../../../../business/accessibility_comments_manager.dart";
-import "../models/toilet.dart";
+import "../../../../../l10n/app_localizations.dart";
+import "../../../business/accessibility_comments_manager.dart";
+import "../data/models/toilet.dart";
 
 class ToiletsAccessibilityCommentsManager extends AccessibilityCommentsManager {
   ToiletsAccessibilityCommentsManager({required this.toilet, required this.l10n});

--- a/lib/features/digital_guide/tabs/structure/presentation/views/railings_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/railings_view.dart
@@ -12,7 +12,7 @@ import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
 import "../../../../presentation/widgets/digital_guide_loading_view.dart";
-import "../../data/bussiness/railings_accessibility_comments_manager.dart";
+import "../../business/railings_accessibility_comments_manager.dart";
 import "../../data/models/railing.dart";
 import "../../data/repository/railings_repository.dart";
 

--- a/lib/features/digital_guide/tabs/structure/presentation/views/ramps_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/ramps_view.dart
@@ -12,7 +12,7 @@ import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
 import "../../../../presentation/widgets/digital_guide_nav_link.dart";
-import "../../data/bussiness/ramps_accessibility_comments_manager.dart";
+import "../../business/ramps_accessibility_comments_manager.dart";
 import "../../data/models/ramp.dart";
 
 @RoutePage()

--- a/lib/features/digital_guide/tabs/structure/presentation/views/stairs_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/stairs_view.dart
@@ -15,7 +15,7 @@ import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
 import "../../../../presentation/widgets/digital_guide_loading_view.dart";
 import "../../../../presentation/widgets/digital_guide_nav_link.dart";
-import "../../data/bussiness/stairs_accessibility_comments_manager.dart";
+import "../../business/stairs_accessibility_comments_manager.dart";
 import "../../data/models/stairs.dart";
 import "../../data/repository/stairs_repository.dart";
 

--- a/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
@@ -13,7 +13,7 @@ import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
 import "../../../../presentation/widgets/digital_guide_nav_link.dart";
 import "../../../../presentation/widgets/digital_guide_photo_row.dart";
-import "../../data/bussiness/stairway_accessibility_comments_manager.dart";
+import "../../business/stairway_accessibility_comments_manager.dart";
 import "../../data/models/stairway.dart";
 
 @RoutePage()

--- a/lib/features/digital_guide/tabs/structure/presentation/views/toilets_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/toilets_view.dart
@@ -11,7 +11,7 @@ import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
 import "../../../../presentation/widgets/digital_guide_nav_link.dart";
-import "../../data/bussiness/toilets_accessibility_comments_manager.dart";
+import "../../business/toilets_accessibility_comments_manager.dart";
 import "../../data/models/toilet.dart";
 
 @RoutePage()


### PR DESCRIPTION
I moved accessibility managers from .../data/business/ to .../business to follow the correct architecture and separation of concerns
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor to move accessibility managers to `business` directory and update import paths accordingly.
> 
>   - **Refactor**:
>     - Move accessibility managers from `data/business` to `business` directory.
>     - Update import paths in `railings_view.dart`, `ramps_view.dart`, `stairs_view.dart`, `stairway_view.dart`, and `toilets_view.dart` to reflect new locations.
>   - **Files Renamed**:
>     - `railings_accessibility_comments_manager.dart`, `ramps_accessibility_comments_manager.dart`, `stairs_accessibility_comments_manager.dart` moved to `business` directory.
>     - `stairway_accessibility_comments_manager.dart`, `toilets_accessibility_comments_manager.dart` moved to `business` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for f1a177dca0eb20e0ba97b8a00c2ea2b47689ac43. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->