### PR TITLE
fix: fill holes in the navigation of digital guide

### DIFF
--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -65,6 +65,8 @@ extension IsRouteATabViewX on PageRouteInfo<dynamic> {
       RegionRoute.name => context.localize.region,
       CorridorRoute.name => context.localize.corridor,
       AdaptedToiletDetailRoute.name => context.localize.adapted_toilets,
+      DigitalGuideEntranceDetailsRoute.name => context.localize.entrances,
+      DigitalGuideRoomDetailRoute.name => context.localize.room_information,
       _ => null,
     };
   }

--- a/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_level.dart
+++ b/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_level.dart
@@ -26,10 +26,7 @@ class AdaptedToiletLevel extends ConsumerWidget {
           physics: const NeverScrollableScrollPhysics(),
           itemBuilder:
               (context, index) => DigitalGuideNavLink(
-                onTap: () async {
-                  debugPrint("halo");
-                  await ref.navigateAdaptedToiletDetails(adaptedToilets[index]);
-                },
+                onTap: () async => ref.navigateAdaptedToiletDetails(adaptedToilets[index]),
                 text: adaptedToilets[index].getDescription(context),
               ),
           separatorBuilder: (context, index) => const SizedBox(height: DigitalGuideConfig.heightMedium),

--- a/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_level.dart
+++ b/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_level.dart
@@ -27,6 +27,7 @@ class AdaptedToiletLevel extends ConsumerWidget {
           itemBuilder:
               (context, index) => DigitalGuideNavLink(
                 onTap: () async {
+                  debugPrint("halo");
                   await ref.navigateAdaptedToiletDetails(adaptedToilets[index]);
                 },
                 text: adaptedToilets[index].getDescription(context),

--- a/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
+++ b/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
@@ -7,6 +7,7 @@ import "../../../../../config/ui_config.dart";
 import "../../../../../theme/app_theme.dart";
 import "../../../../../utils/context_extensions.dart";
 import "../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../navigator/utils/navigation_commands.dart";
 import "../../../presentation/widgets/accessibility_button.dart";
 import "../../../presentation/widgets/bullet_list.dart";
 import "../../../presentation/widgets/digital_guide_nav_link.dart";
@@ -56,8 +57,19 @@ class DigitalGuideEntranceDetailsView extends ConsumerWidget {
       //   icon: Assets.svg.digitalGuide.accessibilityAlerts.blindProfile,
       // ),
       const SizedBox(height: DigitalGuideConfig.heightBig),
-      DigitalGuideNavLink(onTap: () {}, text: context.localize.door),
-      const SizedBox(height: DigitalGuideConfig.heightBig),
+      ListView.separated(
+        physics: const NeverScrollableScrollPhysics(),
+        itemBuilder: (context, index) {
+          return DigitalGuideNavLink(
+            onTap: () async => ref.navigateDigitalGuideDoor(entrance.doorsIndices[index]),
+            text: context.localize.door,
+          );
+        },
+        itemCount: entrance.doorsIndices.length,
+        separatorBuilder: (context, index) => const SizedBox(height: DigitalGuideConfig.heightMedium),
+        shrinkWrap: true,
+      ),
+      const SizedBox(height: DigitalGuideConfig.heightMedium),
       DigitalGuidePhotoRow(imagesIDs: entrance.imagesIndices.lock),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
     ];

--- a/lib/features/digital_guide/tabs/evacuation/entrances_list.dart
+++ b/lib/features/digital_guide/tabs/evacuation/entrances_list.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../../config/ui_config.dart";
 import "../../../../widgets/my_error_widget.dart";
+import "../../../navigator/utils/navigation_commands.dart";
 import "../../data/models/digital_guide_response.dart";
 import "../../presentation/widgets/digital_guide_nav_link.dart";
 import "../entraces/data/repository/entraces_repository.dart";
@@ -18,8 +19,10 @@ class EntrancesList extends ConsumerWidget {
           (entrancesData) => ListView.separated(
             physics: const NeverScrollableScrollPhysics(),
             itemBuilder:
-                (context, index) =>
-                    DigitalGuideNavLink(onTap: () {}, text: entrancesData[index].translations.pl.name ?? ""),
+                (context, index) => DigitalGuideNavLink(
+                  onTap: () async => ref.navigateEntrancesDetails(entrancesData[index]),
+                  text: entrancesData[index].translations.pl.name ?? "",
+                ),
             separatorBuilder: (context, index) => const SizedBox(height: DigitalGuideConfig.heightMedium),
             itemCount: entrancesData.length,
             shrinkWrap: true,

--- a/lib/features/digital_guide/tabs/rooms/presentation/digital_guide_room_detail_view.dart
+++ b/lib/features/digital_guide/tabs/rooms/presentation/digital_guide_room_detail_view.dart
@@ -10,6 +10,7 @@ import "../../../../../utils/ilist_nonempty.dart";
 import "../../../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../widgets/my_expansion_tile.dart";
+import "../../../../navigator/utils/navigation_commands.dart";
 import "../../../presentation/widgets/accessibility_button.dart";
 import "../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../presentation/widgets/bullet_list.dart";
@@ -63,9 +64,19 @@ class DigitalGuideRoomDetailView extends ConsumerWidget {
 
       DigitalGuidePhotoRow(imagesIDs: room.imagesIds.toIList()),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
-      DigitalGuideNavLink(onTap: () {}, text: context.localize.door),
-      const SizedBox(height: DigitalGuideConfig.heightMedium),
-      const SizedBox(height: DigitalGuideConfig.heightMedium),
+      ListView.separated(
+        physics: const NeverScrollableScrollPhysics(),
+        itemBuilder: (context, index) {
+          return DigitalGuideNavLink(
+            onTap: () async => ref.navigateDigitalGuideDoor(room.doors[index]),
+            text: context.localize.door,
+          );
+        },
+        itemCount: room.doors.length,
+        separatorBuilder: (context, index) => const SizedBox(height: DigitalGuideConfig.heightMedium),
+        shrinkWrap: true,
+      ),
+      const SizedBox(height: 2 * DigitalGuideConfig.heightMedium),
       if (room.roomStairs.isNotEmpty)
         ...room.roomStairs.asMap().entries.map((entry) {
           final String index = entry.key == 0 ? "" : (entry.key + 1).toString();

--- a/lib/features/navigator/app_router.dart
+++ b/lib/features/navigator/app_router.dart
@@ -100,6 +100,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: TransportationDetailRoute.page),
     AutoRoute(page: RailingsRoute.page),
     AutoRoute(page: RampsRoute.page),
+    AutoRoute(page: AdaptedToiletDetailRoute.page),
   ];
 }
 


### PR DESCRIPTION
Digital Guide navigation fix, now everything's fine
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes navigation issues in the digital guide by adding missing routes and updating navigation logic across components.
> 
>   - **Navigation Fixes**:
>     - Add `DigitalGuideEntranceDetailsRoute` and `DigitalGuideRoomDetailRoute` to `nav_bar_config.dart` for localization.
>     - Update `DigitalGuideNavLink` in `adapted_toilet_level.dart`, `entraces_detail_view.dart`, `entrances_list.dart`, and `digital_guide_room_detail_view.dart` to use `ref.navigate...` for navigation.
>   - **Routing**:
>     - Add `AdaptedToiletDetailRoute` to `app_router.dart` routes list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for aa4f479c1f147012118f0d7ddc7c5e40015277f9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->