### PR TITLE
fix: change externalId field in digital guide response to nullable

### DIFF
--- a/lib/features/digital_guide/data/models/digital_guide_response.dart
+++ b/lib/features/digital_guide/data/models/digital_guide_response.dart
@@ -9,7 +9,7 @@ part "digital_guide_response.g.dart";
 abstract class DigitalGuideResponse with _$DigitalGuideResponse {
   const factory DigitalGuideResponse({
     required int id,
-    @JsonKey(name: "external_id") required int externalId,
+    @JsonKey(name: "external_id") required int? externalId,
     required DigitalGuideTranslations translations,
     @JsonKey(name: "number_of_storeys") required int numberOfStoreys,
     @JsonKey(name: "is_possibility_to_enter_with_assistance_dog", fromJson: stringToBool)

--- a/lib/features/digital_guide/data/repository/digital_guide_repository.dart
+++ b/lib/features/digital_guide/data/repository/digital_guide_repository.dart
@@ -1,4 +1,3 @@
-import "package:flutter/foundation.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
@@ -19,13 +18,11 @@ Future<({DigitalGuideResponse digitalGuideData, String? photoUrl})> digitalGuide
     orElse: () => throw Exception("No such building: $ourId"),
   );
   final digitalGuideId = building.externalDigitalGuideIdOrURL;
-  debugPrint("before");
   final digitalGuideData = await ref.getAndCacheDataFromDigitalGuide(
     "buildings/$digitalGuideId",
     DigitalGuideResponse.fromJson,
     onRetry: () => ref.invalidateSelf(),
   );
-  debugPrint("after");
 
   return (digitalGuideData: digitalGuideData, photoUrl: building.cover?.filename_disk);
 }

--- a/lib/features/digital_guide/data/repository/digital_guide_repository.dart
+++ b/lib/features/digital_guide/data/repository/digital_guide_repository.dart
@@ -1,3 +1,4 @@
+import "package:flutter/foundation.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
@@ -18,11 +19,13 @@ Future<({DigitalGuideResponse digitalGuideData, String? photoUrl})> digitalGuide
     orElse: () => throw Exception("No such building: $ourId"),
   );
   final digitalGuideId = building.externalDigitalGuideIdOrURL;
+  debugPrint("before");
   final digitalGuideData = await ref.getAndCacheDataFromDigitalGuide(
     "buildings/$digitalGuideId",
     DigitalGuideResponse.fromJson,
     onRetry: () => ref.invalidateSelf(),
   );
+  debugPrint("after");
 
   return (digitalGuideData: digitalGuideData, photoUrl: building.cover?.filename_disk);
 }

--- a/lib/features/digital_guide/presentation/widgets/digital_guide_features_section.dart
+++ b/lib/features/digital_guide/presentation/widgets/digital_guide_features_section.dart
@@ -58,10 +58,11 @@ class DigitalGuideFeaturesSection extends ConsumerWidget {
           title: l10n.adapted_toilets,
           content: [AdaptedToiletsExpansionTileContent(digitalGuideData: digitalGuideData)],
         ),
-      (
-        title: l10n.micro_navigation,
-        content: [MicronavigationExpansionTileContent(digitalGuideData: digitalGuideData)],
-      ),
+      if (digitalGuideData.externalId != null)
+        (
+          title: l10n.micro_navigation,
+          content: [MicronavigationExpansionTileContent(digitalGuideData: digitalGuideData)],
+        ),
       (title: l10n.building_structure, content: [StructureExpansionTileContent(digitalGuideData: digitalGuideData)]),
       (
         title: l10n.room_information,

--- a/lib/features/digital_guide/tabs/micronavigation/presentation/micronavigation_expansion_tile_content.dart
+++ b/lib/features/digital_guide/tabs/micronavigation/presentation/micronavigation_expansion_tile_content.dart
@@ -4,6 +4,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../../../config/ui_config.dart";
 import "../../../../../theme/app_theme.dart";
+import "../../../../../utils/context_extensions.dart";
 import "../../../../../widgets/my_error_widget.dart";
 import "../../../../navigator/utils/navigation_commands.dart";
 import "../../../data/models/digital_guide_response.dart";
@@ -18,7 +19,9 @@ class MicronavigationExpansionTileContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncMicronavigationData = ref.watch(getMicronavigationDataProvider(digitalGuideData.externalId));
+    if (digitalGuideData.externalId == null) return MyErrorWidget(context.localize.no_micro_navigation);
+
+    final asyncMicronavigationData = ref.watch(getMicronavigationDataProvider(digitalGuideData.externalId!));
 
     return asyncMicronavigationData.when(
       data:

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -572,5 +572,7 @@
 
   "corridor_echo" : "{value, select, false{Akustyka korytarza nie powoduje powstawania echa, które może utrudniać komunikację.} true{Akustyka korytarza powoduje powstawanie echa, które może utrudniać komunikację.} other{}}",
 
-  "corridor_flashing_device": "{value, select, false{W korytarzu nie ma obiektów migających lub błyszczących, które mogą wywołać atak epilepsji.} true{W korytarzu znajdują się obiekty migające lub błyszczące, które mogą wywołać atak epilepsji.} other{}}"
+  "corridor_flashing_device": "{value, select, false{W korytarzu nie ma obiektów migających lub błyszczących, które mogą wywołać atak epilepsji.} true{W korytarzu znajdują się obiekty migające lub błyszczące, które mogą wywołać atak epilepsji.} other{}}",
+
+  "no_micro_navigation" : "There is no micronavigation for this building"
 }


### PR DESCRIPTION
Fix Ola's catch pointed out on Discord

external id can be null and then there is no micronavigation
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make `externalId` nullable in `DigitalGuideResponse` and update UI to handle null values for micronavigation.
> 
>   - **Behavior**:
>     - Change `externalId` in `DigitalGuideResponse` to nullable in `digital_guide_response.dart`.
>     - Conditionally display micronavigation section in `DigitalGuideFeaturesSection` if `externalId` is not null.
>     - In `MicronavigationExpansionTileContent`, show error message if `externalId` is null.
>   - **Localization**:
>     - Add `no_micro_navigation` string to `app_pl.arb` for error message when micronavigation is unavailable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 676a8f3c034c973f53981dbf3bdb3e3a36d80ffe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->