### PR TITLE
feat: add date to the offline banner

### DIFF
--- a/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
@@ -88,7 +88,7 @@ class _SksMenuView extends ConsumerWidget {
                 alertType: AlertType.info,
                 title: context.localize.sks_note,
                 message: context.localize.sks_menu_you_see_last_menu(
-                  DateFormat("dd-MM-yyyy").format(sksMenuData.lastUpdate),
+                  DateFormat("dd.MM.yyyy").format(sksMenuData.lastUpdate),
                 ),
               ),
             for (final technicalInfo in sksMenuData.technicalInfos) TechnicalMessage(message: technicalInfo),

--- a/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
@@ -5,6 +5,7 @@ import "package:auto_route/annotations.dart";
 import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
+import "package:intl/intl.dart";
 import "package:lottie/lottie.dart";
 
 import "../../../../../theme/app_theme.dart";
@@ -86,7 +87,9 @@ class _SksMenuView extends ConsumerWidget {
               TechnicalMessage(
                 alertType: AlertType.info,
                 title: context.localize.sks_note,
-                message: context.localize.sks_menu_you_see_last_menu,
+                message: context.localize.sks_menu_you_see_last_menu(
+                  DateFormat("dd-MM-yyyy").format(sksMenuData.lastUpdate),
+                ),
               ),
             for (final technicalInfo in sksMenuData.technicalInfos) TechnicalMessage(message: technicalInfo),
             SksMenuHeader(

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -190,8 +190,7 @@
   "push_notifications_dialog_info": "Obecnie nie korzystamy z powiadomień push, ale planujemy dodać je w przyszłości. Możesz wyrazić na nie zgodę już teraz.",
   "sks_menu_technical_info": "KOMUNIKAT",
   "sks_note": "UWAGA",
-  "sks_menu_you_see_last_menu": "Aktualne menu SKS jest niedostępne. Przeglądasz ostatnio dostępną wersję.",
-  "my_offline_error_message": "Wystąpił błąd podczas pobierania danych dotyczących {data_type}",
+  "sks_menu_you_see_last_menu": "Aktualne menu SKS jest niedostępne. Przeglądasz ostatnio dostępną wersję z: {date}",  "my_offline_error_message": "Wystąpił błąd podczas pobierania danych dotyczących {data_type}",
   "@my_offline_error_message": {
     "description": "An error message with a single parameter",
     "placeholders": {


### PR DESCRIPTION
- the simplest possible solution I guess.

![simulator_screenshot_675C3BC5-1DA0-4CC7-9208-6911E93C805B](https://github.com/user-attachments/assets/14a1a8ae-aabe-4553-8e1b-5ce4abd5cbc7)

#641 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds date to the offline banner in SKS menu screen and updates localization string to include date.
> 
>   - **Behavior**:
>     - Adds date to offline banner in `_SksMenuView` in `sks_menu_screen.dart` using `DateFormat` from `intl` package.
>     - Updates localization string `sks_menu_you_see_last_menu` in `app_pl.arb` to include date placeholder.
>   - **Imports**:
>     - Adds `import "package:intl/intl.dart";` to `sks_menu_screen.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 9b27fe169453dc585162f2833379a17bd3db2ce6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->