### PR TITLE
fix: convert Polish time from API to UTC in sks chart model

### DIFF
--- a/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
+++ b/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
@@ -18,10 +18,6 @@ abstract class SksChartData with _$SksChartData {
   factory SksChartData.fromJson(Map<String, dynamic> json) => _$SksChartDataFromJson(json);
 }
 
-// DateTime toLocalPolish(String dateTimeString) {
-//   return DateTime.parse(dateTimeString).toUtc().toLocal();
-// }
-
 extension SksChartDataIListX on IList<SksChartData> {
   double get maxNumberOfUsers {
     return map(

--- a/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
+++ b/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
@@ -1,4 +1,5 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/foundation.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
 part "sks_chart_data.freezed.dart";
@@ -9,10 +10,14 @@ abstract class SksChartData with _$SksChartData {
   const factory SksChartData({
     required int activeUsers,
     required int movingAverage21,
-    required DateTime externalTimestamp,
+    @JsonKey(fromJson: toLocalPolish) required DateTime externalTimestamp,
   }) = _SksChartData;
 
   factory SksChartData.fromJson(Map<String, dynamic> json) => _$SksChartDataFromJson(json);
+}
+
+DateTime toLocalPolish(String dateTimeString) {
+  return DateTime.parse(dateTimeString).toUtc().toLocal();
 }
 
 extension SksChartDataIListX on IList<SksChartData> {

--- a/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
+++ b/lib/features/sks/sks_chart/data/models/sks_chart_data.dart
@@ -2,6 +2,8 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/foundation.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../../../../../utils/datetime_utils.dart";
+
 part "sks_chart_data.freezed.dart";
 part "sks_chart_data.g.dart";
 
@@ -10,15 +12,15 @@ abstract class SksChartData with _$SksChartData {
   const factory SksChartData({
     required int activeUsers,
     required int movingAverage21,
-    @JsonKey(fromJson: toLocalPolish) required DateTime externalTimestamp,
+    @JsonKey(fromJson: fromJsonToLocalTime) required DateTime externalTimestamp,
   }) = _SksChartData;
 
   factory SksChartData.fromJson(Map<String, dynamic> json) => _$SksChartDataFromJson(json);
 }
 
-DateTime toLocalPolish(String dateTimeString) {
-  return DateTime.parse(dateTimeString).toUtc().toLocal();
-}
+// DateTime toLocalPolish(String dateTimeString) {
+//   return DateTime.parse(dateTimeString).toUtc().toLocal();
+// }
 
 extension SksChartDataIListX on IList<SksChartData> {
   double get maxNumberOfUsers {

--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_labels.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_labels.dart
@@ -39,8 +39,7 @@ class SksChartBottomTitles extends AxisTitles {
           reservedSize: 35,
           interval: 5,
           getTitlesWidget: (double value, TitleMeta meta) {
-            final DateTime? hourMinute =
-                chartData.isNotEmpty ? chartData[value.toInt()].externalTimestamp.toLocal() : null;
+            final DateTime? hourMinute = chartData.isNotEmpty ? chartData[value.toInt()].externalTimestamp : null;
             final String hourMinuteFormatted =
                 hourMinute != null && hourMinute.minute == 0 ? hourMinute.toHourMinuteString() : "";
 

--- a/lib/features/sks/sks_people_live/data/models/sks_user_data.dart
+++ b/lib/features/sks/sks_people_live/data/models/sks_user_data.dart
@@ -1,5 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../../../../../utils/datetime_utils.dart";
+
 part "sks_user_data.freezed.dart";
 part "sks_user_data.g.dart";
 
@@ -8,7 +10,7 @@ abstract class SksUserData with _$SksUserData {
   const factory SksUserData({
     required int activeUsers,
     required int movingAverage21,
-    required DateTime externalTimestamp,
+    @JsonKey(fromJson: fromJsonToLocalTime) required DateTime externalTimestamp,
     required DateTime createdAt,
     required DateTime updatedAt,
     required Trend trend,

--- a/lib/utils/datetime_utils.dart
+++ b/lib/utils/datetime_utils.dart
@@ -44,3 +44,7 @@ extension DateTimeUtilsX on DateTime {
     return isAfter(other) || isAtSameMomentAs(other);
   }
 }
+
+DateTime fromJsonToLocalTime(String dataTimeString) {
+  return DateTime.parse(dataTimeString).toLocal();
+}


### PR DESCRIPTION
I convert Polish time to user local time in sks chart model

<img width="369" alt="image" src="https://github.com/user-attachments/assets/b76108d3-9d2e-4682-aecb-27b0a4361230" width="256"/>
<img width="369" alt="image" src="https://github.com/user-attachments/assets/171daa13-2fe7-41da-878b-3432e786c9bf" width="256"/>

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Convert Polish time to local time in `SksChartData` and `SksUserData` models using `fromJsonToLocalTime`.
> 
>   - **Behavior**:
>     - Convert Polish time to local time using `fromJsonToLocalTime` in `SksChartData` and `SksUserData` models.
>     - Update `externalTimestamp` field in `sks_chart_data.dart` and `sks_user_data.dart` to use `fromJsonToLocalTime`.
>   - **Functions**:
>     - Add `fromJsonToLocalTime` in `datetime_utils.dart` to parse and convert time to local.
>   - **Presentation**:
>     - Remove `toLocal()` call in `SksChartBottomTitles` in `sks_chart_labels.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 37d31c97c328c354bfcdc646d1738412168cff3b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->