### PR TITLE
feat: add hour label and enable dots

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -121,7 +121,6 @@ abstract class ParkingsConfig {
 
 abstract class ParkingChartConfig {
   static final showLabels = generateRangeHourPoints(6, 22).toList();
-
 }
 
 abstract class AboutUsConfig {

--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -120,8 +120,8 @@ abstract class ParkingsConfig {
 }
 
 abstract class ParkingChartConfig {
-  static final showLabels = generateRangeHourPoints(6, 22, 2).toList();
-  static final showDots = generateRangeHourPoints(5, 22).toList();
+  static final showLabels = generateRangeHourPoints(6, 22).toList();
+
 }
 
 abstract class AboutUsConfig {

--- a/lib/features/parkings/parking_chart/chart_elements/chart_line.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/chart_line.dart
@@ -4,7 +4,6 @@ import "package:flutter/material.dart";
 
 import "../../../../theme/app_theme.dart";
 import "../models/chart_point.dart";
-import "../utils/chart_utils.dart";
 
 class ChartLine extends LineChartBarData {
   ChartLine(BuildContext context, IList<ChartPoint> chartData)
@@ -13,7 +12,7 @@ class ChartLine extends LineChartBarData {
         color: context.colorTheme.greyLight,
         barWidth: 1,
         isStrokeCapRound: true,
-        dotData: const FlDotData(checkToShowDot: ChartUtilsX.showDotOrNot),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(show: true, color: context.colorTheme.blueAzure.withValues(alpha: 0.2)),
         spots: chartData.unlockLazy,
       );

--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -9,22 +9,23 @@ const double rotationAngle = -45;
 
 class BottomLabels extends AxisTitles {
   BottomLabels(BuildContext context)
-    : super(
-        sideTitles: SideTitles(
-          showTitles: true,
-          interval: 1,
-          reservedSize: 48,
-          getTitlesWidget:
-              (double val, _) => Padding(
-                padding: const EdgeInsets.only(top: 4),
-                child: Transform.rotate(
-                  angle: rotationAngle.radians,
-                  child: SideTitleWidget(
-                    axisSide: AxisSide.bottom,
-                    child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
-                  ),
-                ),
-              ),
+      : super(
+    sideTitles: SideTitles(
+      showTitles: true,
+      interval: 1,
+      reservedSize: 48,
+      getTitlesWidget:
+          (double val, TitleMeta meta) =>
+              Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Transform.rotate(
+          angle: rotationAngle.radians,
+          child: SideTitleWidget(
+            meta: meta,
+            child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
+          ),
         ),
-      );
+      ),
+    ),
+  );
 }

--- a/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_bottom.dart
@@ -9,23 +9,22 @@ const double rotationAngle = -45;
 
 class BottomLabels extends AxisTitles {
   BottomLabels(BuildContext context)
-      : super(
-    sideTitles: SideTitles(
-      showTitles: true,
-      interval: 1,
-      reservedSize: 48,
-      getTitlesWidget:
-          (double val, TitleMeta meta) =>
-              Padding(
-        padding: const EdgeInsets.only(top: 4),
-        child: Transform.rotate(
-          angle: rotationAngle.radians,
-          child: SideTitleWidget(
-            meta: meta,
-            child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
-          ),
+    : super(
+        sideTitles: SideTitles(
+          showTitles: true,
+          interval: 1,
+          reservedSize: 48,
+          getTitlesWidget:
+              (double val, TitleMeta meta) => Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Transform.rotate(
+                  angle: rotationAngle.radians,
+                  child: SideTitleWidget(
+                    meta: meta,
+                    child: Text(ChartUtilsX.getLabelForValue(val), style: context.iParkingTheme.chart),
+                  ),
+                ),
+              ),
         ),
-      ),
-    ),
-  );
+      );
 }

--- a/lib/features/parkings/parking_chart/chart_elements/labels_left.dart
+++ b/lib/features/parkings/parking_chart/chart_elements/labels_left.dart
@@ -20,7 +20,7 @@ class LeftLabels extends AxisTitles {
               return const SizedBox.shrink();
             }
             return SideTitleWidget(
-              axisSide: AxisSide.left,
+              meta: meta,
               space: 10,
               child: Text(meta.formattedValue, style: context.iParkingTheme.chart),
             );

--- a/lib/features/parkings/parking_chart/utils/chart_utils.dart
+++ b/lib/features/parkings/parking_chart/utils/chart_utils.dart
@@ -2,7 +2,6 @@ import "dart:math";
 
 import "package:collection/collection.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
-import "package:fl_chart/fl_chart.dart";
 
 import "../../../../config/ui_config.dart";
 import "../../parkings_view/models/parking.dart";
@@ -22,5 +21,4 @@ extension ChartUtilsX on IList<ChartPoint> {
     }
     return hourPoint.toStringRepr();
   }
-
 }

--- a/lib/features/parkings/parking_chart/utils/chart_utils.dart
+++ b/lib/features/parkings/parking_chart/utils/chart_utils.dart
@@ -23,7 +23,4 @@ extension ChartUtilsX on IList<ChartPoint> {
     return hourPoint.toStringRepr();
   }
 
-  static bool showDotOrNot(FlSpot spot, LineChartBarData barData) {
-    return ParkingChartConfig.showDots.contains(spot.x);
-  }
 }

--- a/lib/features/parkings/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parkings/parking_chart/widgets/chart_widget.dart
@@ -49,7 +49,7 @@ class ChartWidget extends StatelessWidget {
                       final hour = HourLabel(touchedSpot.x).toStringRepr();
                       final value = touchedSpot.y.toInt(); // Convert double to int
                       return LineTooltipItem(
-                        "$hour\n$value",
+                        "$value\n$hour",
                         TextStyle(color: context.colorTheme.whiteSoap, fontWeight: FontWeight.bold),
                       );
                     }).toList();

--- a/lib/features/parkings/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parkings/parking_chart/widgets/chart_widget.dart
@@ -11,6 +11,7 @@ import "../chart_elements/chart_line.dart";
 import "../chart_elements/labels_bottom.dart";
 import "../chart_elements/labels_left.dart";
 import "../models/chart_point.dart";
+import "../models/hour_label.dart";
 import "../utils/chart_utils.dart";
 import "reversed_label.dart";
 
@@ -45,9 +46,10 @@ class ChartWidget extends StatelessWidget {
                 touchTooltipData: LineTouchTooltipData(
                   getTooltipItems: (touchedSpots) {
                     return touchedSpots.map((touchedSpot) {
+                      final hour = HourLabel(touchedSpot.x).toStringRepr();
                       final value = touchedSpot.y.toInt(); // Convert double to int
                       return LineTooltipItem(
-                        value.toString(),
+                        "$hour\n$value",
                         TextStyle(color: context.colorTheme.whiteSoap, fontWeight: FontWeight.bold),
                       );
                     }).toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,7 +78,7 @@ dependencies:
       url: https://github.com/ChrisElliotUK/auto_size_text.git
       ref: patch-1
   lottie: ^3.3.1
-  fl_chart: ^0.69.2
+  fl_chart: ^0.70.2
   animated_list_plus: ^0.5.2
   dotted_border: ^2.1.0
   fluttertoast: ^8.2.12


### PR DESCRIPTION
I added hour label and removed dots.
![image](https://github.com/user-attachments/assets/49e81e3e-a6a6-486f-8a13-5e7faa7ff1ff)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add hour labels to parking chart tooltips and disable dots on chart lines.
> 
>   - **Behavior**:
>     - Added hour labels to parking chart tooltips in `chart_widget.dart`.
>     - Disabled dots on chart lines by setting `dotData: const FlDotData(show: false)` in `chart_line.dart`.
>   - **Configuration**:
>     - Removed `showDots` from `ParkingChartConfig` in `ui_config.dart`.
>     - Updated `fl_chart` dependency to `^0.70.2` in `pubspec.yaml`.
>   - **Misc**:
>     - Updated `getTitlesWidget` in `labels_bottom.dart` and `labels_left.dart` to include `TitleMeta meta` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 0ffcc8327ed2ab0eb5f8819985a1bae963734ec1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->