### PR TITLE
bug(digital-guide): fix accessibility panel colors

### DIFF
--- a/lib/features/digital_guide/presentation/widgets/accessibility_information_card.dart
+++ b/lib/features/digital_guide/presentation/widgets/accessibility_information_card.dart
@@ -24,8 +24,10 @@ class AccessibilityInformationCard extends StatelessWidget {
         // if it's not HTML, we limit it to 2 lines, so the minHeight = height in such case
       ),
       decoration: BoxDecoration(
+        boxShadow: [BoxShadow(color: Colors.black.withAlpha(64), offset: const Offset(0, 4), blurRadius: 4)],
+        border: Border(left: BorderSide(color: color, width: 10)),
         borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
-        color: color,
+        color: context.colorTheme.whiteSoap,
       ),
       child: Row(
         children: [
@@ -35,8 +37,9 @@ class AccessibilityInformationCard extends StatelessWidget {
               width: DigitalGuideConfig.difficultiesCardIconSize,
               height: DigitalGuideConfig.difficultiesCardIconSize,
               decoration: BoxDecoration(
+                border: Border.all(color: color),
                 borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusSmall),
-                color: Colors.white,
+                color: context.colorTheme.whiteSoap,
               ),
               child: Center(
                 child: SizedBox.square(dimension: 20, child: SvgPicture.asset(icon, height: 20, width: 20)),
@@ -51,9 +54,9 @@ class AccessibilityInformationCard extends StatelessWidget {
                   isHTML
                       ? Padding(
                         padding: const EdgeInsets.all(DigitalGuideConfig.heightSmall),
-                        child: MyHtmlWidget(text, textStyle: context.textTheme.bodyWhite),
+                        child: MyHtmlWidget(text, textStyle: context.textTheme.body),
                       )
-                      : Text(text, style: context.textTheme.bodyWhite, overflow: TextOverflow.ellipsis, maxLines: 2),
+                      : Text(text, style: context.textTheme.body, overflow: TextOverflow.ellipsis, maxLines: 2),
             ),
           ),
         ],


### PR DESCRIPTION
Changed accessibility profile card design to sth like this. Colorful background is sadly unachievable, so i decided to put it as black on white ;) 

![image](https://github.com/user-attachments/assets/e36dbe15-8df7-4755-b8fe-d7fad73547ef)
