### PR TITLE
fix: prevent sks chart exceeding available height

### DIFF
--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart.dart
@@ -19,10 +19,9 @@ class SksChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: SksChartConfig.paddingLarge),
-      child: AspectRatio(
-        aspectRatio: 1.5,
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.only(right: SksChartConfig.paddingLarge),
         child: LineChart(
           duration: Duration.zero,
           LineChartData(

--- a/lib/features/sks/sks_chart/presentation/sks_chart_card.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_card.dart
@@ -24,6 +24,7 @@ class SksChartCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      margin: const EdgeInsets.symmetric(horizontal: SksChartConfig.paddingMedium),
       width: double.infinity,
       decoration: BoxDecoration(
         color: context.colorTheme.greyLight,

--- a/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
@@ -29,7 +29,7 @@ class SksChartSheet extends ConsumerWidget {
     final maxNumberOfUsers = asyncChartData.value?.maxNumberOfUsers ?? 0;
 
     final screenWidth = MediaQuery.sizeOf(context).width;
-    final sheetHeight = useFiltersSheetHeight(context, prefferedHeightFactor: screenWidth > 400 ? .62 : .68);
+    final sheetHeight = useFiltersSheetHeight(context, prefferedHeightFactor: screenWidth > 400 ? .72 : .84);
 
     return switch (asyncChartData) {
       AsyncError(:final error) => MyErrorWidget(error),
@@ -45,23 +45,15 @@ class SksChartSheet extends ConsumerWidget {
                 child: const _SksSheetHeader(),
               ),
               Expanded(
-                child: ListView(
-                  physics: const NeverScrollableScrollPhysics(),
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: SksChartConfig.paddingMedium),
-                      child: SksChartCard(
-                        currentNumberOfUsers: currentNumberOfUsers,
-                        maxNumberOfUsers: maxNumberOfUsers,
-                        chartData: asyncChartData.value ?? const IList.empty(),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.all(SksChartConfig.paddingSmall),
-                      child: TextAndUrl(SksChartConfig.sksChartDataUrl, "${context.localize.data_come_from_website}: "),
-                    ),
-                  ],
+                child: SksChartCard(
+                  currentNumberOfUsers: currentNumberOfUsers,
+                  maxNumberOfUsers: maxNumberOfUsers,
+                  chartData: asyncChartData.value ?? const IList.empty(),
                 ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(SksChartConfig.paddingSmall),
+                child: TextAndUrl(SksChartConfig.sksChartDataUrl, "${context.localize.data_come_from_website}: "),
               ),
             ],
           ),


### PR DESCRIPTION
Hello

All it took to do this task was to approach it from different angle with fresh perspective haha

# Screenshots

<img width="1364" alt="image" src="https://github.com/user-attachments/assets/b59902a6-a353-4970-b2d6-00ba8544819c" />
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/493d32c3-f80e-44a3-b4c6-0259cc79acf9" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjust SKS chart layout to prevent exceeding available height by using `Expanded` and adjusting margins and padding.
> 
>   - **Layout Adjustments**:
>     - In `sks_chart.dart`, replaced `Padding` with `Expanded` to ensure the chart uses available space without exceeding it.
>     - In `sks_chart_card.dart`, added horizontal margin to `Container` to better fit the chart within the card.
>     - In `sks_chart_sheet.dart`, adjusted `useFiltersSheetHeight` to increase preferred height factor for screens wider than 400px.
>   - **Code Simplification**:
>     - Removed unnecessary `ListView` in `sks_chart_sheet.dart` and directly used `SksChartCard` and `TextAndUrl` widgets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 235ed8a75cbb81b386c76aa778976befea55ced2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->