### PR TITLE
feat: add status to graphql and show only active circles

### DIFF
--- a/lib/features/science_club/science_clubs_view/repository/getScienceClubs.graphql
+++ b/lib/features/science_club/science_clubs_view/repository/getScienceClubs.graphql
@@ -2,6 +2,7 @@ query GetScienceClubs {
   Scientific_Circles(limit: 300) {
     id
     name
+    status
     department {
       id
       name

--- a/lib/features/science_club/science_clubs_view/repository/science_clubs_repository.dart
+++ b/lib/features/science_club/science_clubs_view/repository/science_clubs_repository.dart
@@ -15,7 +15,10 @@ typedef ScienceClub = Query$GetScienceClubs$Scientific_Circles;
 @riverpod
 Future<IList<ScienceClub>> scienceClubsRepository(Ref ref) async {
   final results = await ref.queryGraphql(Options$Query$GetScienceClubs(), TtlKey.scienceClubsRepository);
-  return (results?.Scientific_Circles.sortBySourceTypes()).toIList();
+  return (results?.Scientific_Circles
+          .where((club) => club.status.toScienceClubStatus != ScienceClubStatus.archived)
+          .sortBySourceTypes())
+      .toIList();
 }
 
 extension IsSolvroX on ScienceClub {
@@ -54,4 +57,11 @@ extension SortBySourceTypeX on Iterable<ScienceClub> {
       ...studentDepartmentSourceWithoutPhotos,
     ];
   }
+}
+
+enum ScienceClubStatus { active, archived }
+
+extension ScienceClubStatusX on String? {
+  ScienceClubStatus get toScienceClubStatus =>
+      this == "archived" ? ScienceClubStatus.archived : ScienceClubStatus.active;
 }

--- a/lib/features/science_club/science_clubs_view/widgets/science_clubs_list.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/science_clubs_list.dart
@@ -21,7 +21,9 @@ class ScienceClubsList extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: ScienceClubsViewConfig.mediumPadding),
       child: switch (state) {
-        AsyncValue(:final IList<ScienceClub> value) => _ScienceClubsListView(value),
+        AsyncValue(:final IList<ScienceClub> value) => _ScienceClubsListView(
+          value.where((club) => club.status != "archived").toIList(),
+        ),
         AsyncError(:final error) => MyErrorWidget(error),
         _ => const ScienceClubsViewLoading(),
       },

--- a/lib/features/science_club/science_clubs_view/widgets/science_clubs_list.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/science_clubs_list.dart
@@ -21,9 +21,7 @@ class ScienceClubsList extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: ScienceClubsViewConfig.mediumPadding),
       child: switch (state) {
-        AsyncValue(:final IList<ScienceClub> value) => _ScienceClubsListView(
-          value.where((club) => club.status != "archived").toIList(),
-        ),
+        AsyncValue(:final IList<ScienceClub> value) => _ScienceClubsListView(value),
         AsyncError(:final error) => MyErrorWidget(error),
         _ => const ScienceClubsViewLoading(),
       },


### PR DESCRIPTION
I added "status" to graphql and modified ScienceClubsList to not show archived clubs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add status filtering for science clubs and a settings page for language selection.
> 
>   - **Behavior**:
>     - Adds `status` field to `Scientific_Circles` in `getScienceClubs.graphql` to filter out archived clubs.
>     - Updates `scienceClubsRepository` in `science_clubs_repository.dart` to exclude archived clubs.
>     - Adds `SettingsView` in `settings.dart` for language selection.
>   - **UI Components**:
>     - Adds `SettingsTitle` widget in `settings_title.dart` to navigate to settings.
>     - Updates `NavigationTabView` in `navigation_tab_view.dart` to include settings navigation.
>     - Adds `LanguageDialog` in `language_settings_view.dart` for language selection.
>   - **GraphQL**:
>     - Adds `titleColor` to `PlannerAdvert` in `getPlannerAdvertContent.graphql`.
>   - **Localization**:
>     - Updates `app_en.arb` and `app_pl.arb` for language selection strings.
>   - **Misc**:
>     - Updates `TechnicalMessage` in `technical_message.dart` to support `titleColor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 733b3c05d6c78d57c4292811677d3bdf7b0f2314. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->