### PR TITLE
feat: add digital guide accessibility to settings screen

### DIFF
--- a/lib/features/settings/settings.dart
+++ b/lib/features/settings/settings.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:auto_route/auto_route.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -8,6 +10,7 @@ import "../../../../theme/app_theme.dart";
 import "../../../../utils/context_extensions.dart";
 import "../../services/translations_service/business/translations_notifier.dart";
 import "../../services/translations_service/data/models/supported_languages.dart";
+import "../digital_guide/tabs/accessibility_dialog/presentation/accessibility_dialog.dart";
 import "../navigation_tab_view/widgets/navigation_tile.dart";
 import "widgets/language_settings_view.dart";
 
@@ -29,6 +32,12 @@ class SettingsView extends ConsumerWidget {
         },
         title: context.localize.language,
         icon: Icons.speaker_notes_rounded,
+      ),
+
+      NavigationTile(
+        onTap: () => unawaited(showDialog(context: context, builder: (_) => const AccessibilityDialog())),
+        title: context.localize.digital_guide_accessibility,
+        icon: Icons.accessibility_new,
       ),
     ];
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -749,5 +749,6 @@
   "is_graphic": "Drzwi {value, select, false{nie } other{}}są oznakowane.",
   "is_closure_from_inside": "Drzwi {value, select, false{nie } other{}}otwierają się do wewnątrz.",
   "is_same_opening_system": "Drzwi po obu stronach {value, select, false{nie } other{}}otwierają się w identyczny sposób.",
-  "entrance_has_tactile_paving": "{value, select, false{Brak ścieżki dotykowej przy wejściu.} true{Przy wejściu znajduje się ścieżka dotykowa.} other{}}"
+  "entrance_has_tactile_paving": "{value, select, false{Brak ścieżki dotykowej przy wejściu.} true{Przy wejściu znajduje się ścieżka dotykowa.} other{}}",
+  "digital_guide_accessibility" : "Accessibility profiles in the digital guide"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -742,5 +742,6 @@
   "is_graphic": "Drzwi {value, select, false{nie } other{}}są oznakowane.",
   "is_closure_from_inside": "Drzwi {value, select, false{nie } other{}}otwierają się do wewnątrz.",
   "is_same_opening_system": "Drzwi po obu stronach {value, select, false{nie } other{}}otwierają się w identyczny sposób.",
-  "entrance_has_tactile_paving": "{value, select, false{Brak ścieżki dotykowej przy wejściu.} true{Przy wejściu znajduje się ścieżka dotykowa.} other{}}"
+  "entrance_has_tactile_paving": "{value, select, false{Brak ścieżki dotykowej przy wejściu.} true{Przy wejściu znajduje się ścieżka dotykowa.} other{}}",
+  "digital_guide_accessibility" : "Profile dostępności w cyfrowym przewodniku"
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add digital guide accessibility option to settings screen with UI and localization updates.
> 
>   - **UI Changes**:
>     - Added `NavigationTile` in `SettingsView` in `settings.dart` for digital guide accessibility.
>     - `NavigationTile` opens `AccessibilityDialog` on tap.
>   - **Localization**:
>     - Added `digital_guide_accessibility` string to `app_en.arb` and `app_pl.arb` for English and Polish translations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for ad1eb0f665c24302e43f54a859f4985450cf7274. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->