### PR TITLE
fix(map): map tile layer caching

### DIFF
--- a/.github/workflows/pr_title_ci.yaml
+++ b/.github/workflows/pr_title_ci.yaml
@@ -20,5 +20,5 @@ jobs:
         run: flutter pub get
 
       - name: Validate Title of PR
-        run: echo ${{github.event.pull_request.title}} | dart run commitlint_cli
+        run: echo "${{ github.event.pull_request.title }}" | dart run commitlint_cli
   

--- a/lib/config/map_view_config.dart
+++ b/lib/config/map_view_config.dart
@@ -51,7 +51,7 @@ abstract class OpenStreetMapConfig {
 abstract class MapCacheConfig {
   // in days
   static const cacheDuration = 30;
-  static const cacheBoxName = "HiveMapCacheStore";
+  static const cacheDatabaseName = "map_cache_drift";
 }
 
 abstract class BuildingSearchConfig {

--- a/lib/features/map_view/data/cache.dart
+++ b/lib/features/map_view/data/cache.dart
@@ -1,0 +1,20 @@
+import "package:dio_cache_interceptor_db_store/dio_cache_interceptor_db_store.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:path_provider/path_provider.dart" show getTemporaryDirectory;
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../../config/map_view_config.dart";
+
+part "cache.g.dart";
+
+@Riverpod(keepAlive: true)
+Future<String> mapCacheDir(Ref ref) async {
+  final directory = await getTemporaryDirectory();
+  return directory.path;
+}
+
+@Riverpod(keepAlive: true)
+Future<DbCacheStore> mapCacheStore(Ref ref) async {
+  final directory = await ref.watch(mapCacheDirProvider.future);
+  return DbCacheStore(databaseName: MapCacheConfig.cacheDatabaseName, databasePath: directory);
+}

--- a/lib/features/splash_screen/splash_screen_controller.dart
+++ b/lib/features/splash_screen/splash_screen_controller.dart
@@ -9,6 +9,7 @@ import "../../api_base/hive_init.dart";
 import "../../config/ui_config.dart";
 import "../../firebase_init.dart";
 import "../home_view/widgets/logo_app_bar.dart";
+import "../map_view/data/cache.dart";
 
 part "splash_screen_controller.g.dart";
 
@@ -23,6 +24,7 @@ class SplashScreenController extends _$SplashScreenController {
     await firebaseInit();
     await initHiveForGraphqlCache();
     await AppBarLogo.precacheImageIfAbsent();
+    await ref.read(mapCacheStoreProvider.future); // prefetch map cache directory
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,10 +55,10 @@ dependencies:
   hive: ^2.2.3
   shared_preferences: ^2.5.2
   cached_network_image: ^3.4.1
-  dio_cache_interceptor_hive_store: ^4.0.0
   flutter_cache_manager: ^3.4.1
   drift: ^2.26.0
   drift_flutter: ^0.2.4
+  dio_cache_interceptor_db_store: ^6.0.0
 
   #Network
   url_launcher: ^6.3.1


### PR DESCRIPTION
# before the fix
<img width="430" alt="Zrzut ekranu 2025-04-4 o 19 55 54" src="https://github.com/user-attachments/assets/ccaa1b00-906c-404e-a36e-523daf1ab23c" />

# after the fix 

<img width="775" alt="Zrzut ekranu 2025-04-4 o 20 43 06" src="https://github.com/user-attachments/assets/3492954a-0ef0-404b-9aab-41e2426fad26" />


 I also migrated from hive to drift, so ideally after we drop graphql, we'll be able to drop hive entirely
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrated map tile layer caching from Hive to Drift, updated configurations, and adjusted dependencies for improved map performance.
> 
>   - **Caching Migration**:
>     - Migrated map tile layer caching from Hive to Drift in `map_widget.dart` and `cache.dart`.
>     - Updated `MapCacheConfig` in `map_view_config.dart` to use `cacheDatabaseName` instead of `cacheBoxName`.
>   - **Widget Changes**:
>     - Introduced `MapTileLayer` in `map_widget.dart` to handle tile layer with Drift-based caching.
>     - Prefetch map cache directory in `SplashScreenController` in `splash_screen_controller.dart`.
>   - **Dependencies**:
>     - Removed `dio_cache_interceptor_hive_store` and added `dio_cache_interceptor_db_store` in `pubspec.yaml`.
>   - **Misc**:
>     - Minor syntax fix in `.github/workflows/pr_title_ci.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for baa56d52c8b3e28c85da0e9d517e9d884bf28d5f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->