### PR TITLE
refactor(navigation): make navigation more reliable (perhaps simpler too)

### DIFF
--- a/.github/workflows/pr_title_ci.yaml
+++ b/.github/workflows/pr_title_ci.yaml
@@ -20,5 +20,5 @@ jobs:
         run: flutter pub get
 
       - name: Validate Title of PR
-        run: echo ${{github.event.pull_request.title}} | dart run commitlint_cli
+        run: echo "${{ github.event.pull_request.title }}" | dart run commitlint_cli
   

--- a/lib/config/map_view_config.dart
+++ b/lib/config/map_view_config.dart
@@ -51,7 +51,7 @@ abstract class OpenStreetMapConfig {
 abstract class MapCacheConfig {
   // in days
   static const cacheDuration = 30;
-  static const cacheBoxName = "HiveMapCacheStore";
+  static const cacheDatabaseName = "map_cache_drift";
 }
 
 abstract class BuildingSearchConfig {

--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -1,5 +1,4 @@
 import "package:auto_route/auto_route.dart";
-import "package:collection/collection.dart";
 import "package:flutter/material.dart";
 
 import "../features/bottom_nav_bar/bottom_nav_bar_icon_icons.icons.dart";
@@ -29,26 +28,15 @@ abstract class NavBarConfig {
     NavBarEnum.guide: const GuideRoute(),
     NavBarEnum.navigation: const NavigationTabRoute(),
   };
+
+  // same but reversed key-value pairs
+  static Map<String, NavBarEnum> get reversedTabViews =>
+      Map.fromEntries(tabViews.entries.map((e) => MapEntry(e.value.routeName, e.key)));
 }
 
-extension IsRouteATabViewOnStringX on String {
-  NavBarEnum? get tabBarEnum =>
-      NavBarConfig.tabViews.entries.firstWhereOrNull((entry) => entry.value.routeName == this)?.key;
-
-  bool get isTabView => NavBarConfig.tabViews.values.map((i) => i.routeName).contains(this);
-
-  bool get isRouteGlobalRoute => this == RootRoute.name;
-}
-
-extension IsRouteATabViewX on PageRouteInfo<dynamic> {
-  NavBarEnum? get tabBarEnum => routeName.tabBarEnum;
-
-  bool get isTabView => routeName.isTabView;
-
-  bool get isRouteGlobalRoute => routeName.isRouteGlobalRoute;
-
-  String? getFormatedRouteName(BuildContext context) {
-    return switch (routeName) {
+extension GetFormattedRouteNameX on Route<dynamic> {
+  String? getFormattedRouteName(BuildContext context) {
+    return switch (settings.name) {
       HomeRoute.name => context.localize.home_screen,
       NavigationTabRoute.name => context.localize.other_view,
       DepartmentsRoute.name => context.localize.departments,

--- a/lib/features/bottom_nav_bar/bottom_nav_bar.dart
+++ b/lib/features/bottom_nav_bar/bottom_nav_bar.dart
@@ -5,12 +5,13 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../config/nav_bar_config.dart";
 import "../../theme/app_theme.dart";
 import "../navigator/navigation_controller.dart";
+import "bottom_nav_bar_controller.dart";
 
 class BottomNavBar extends ConsumerWidget {
   const BottomNavBar({super.key});
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final activeTab = ref.watch(navigationControllerProvider).activeTab;
+    final activeTab = ref.watch(bottomNavBarControllerProvider);
     return Theme(
       data: Theme.of(context).copyWith(splashColor: Colors.transparent, highlightColor: Colors.transparent),
       child: DecoratedBox(

--- a/lib/features/bottom_nav_bar/bottom_nav_bar_controller.dart
+++ b/lib/features/bottom_nav_bar/bottom_nav_bar_controller.dart
@@ -1,0 +1,13 @@
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../config/nav_bar_config.dart";
+import "../navigator/navigation_stack.dart";
+
+part "bottom_nav_bar_controller.g.dart";
+
+@riverpod
+NavBarEnum bottomNavBarController(Ref ref) {
+  final lastRoute = ref.watch(currentRouteProvider);
+  return NavBarConfig.reversedTabViews[lastRoute?.settings.name] ?? NavBarEnum.home;
+}

--- a/lib/features/buildings_view/controllers.dart
+++ b/lib/features/buildings_view/controllers.dart
@@ -8,9 +8,9 @@ import "../map_view/controllers/bottom_sheet_controller.dart";
 import "../map_view/controllers/controllers_set.dart";
 import "../map_view/controllers/map_controller.dart";
 import "../map_view/controllers/map_data_controller.dart";
-import "./utils/building_codes_utils.dart";
 import "model/building_model.dart";
 import "repository/buildings_repository.dart";
+import "utils/building_codes_utils.dart";
 import "utils/utils.dart";
 
 part "controllers.g.dart";

--- a/lib/features/digital_guide/tabs/structure/data/models/toilet.dart
+++ b/lib/features/digital_guide/tabs/structure/data/models/toilet.dart
@@ -1,8 +1,8 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 
-part "toilet.g.dart";
 part "toilet.freezed.dart";
+part "toilet.g.dart";
 
 @freezed
 abstract class Toilet with _$Toilet {

--- a/lib/features/map_view/data/cache.dart
+++ b/lib/features/map_view/data/cache.dart
@@ -1,0 +1,20 @@
+import "package:dio_cache_interceptor_db_store/dio_cache_interceptor_db_store.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:path_provider/path_provider.dart" show getTemporaryDirectory;
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../../config/map_view_config.dart";
+
+part "cache.g.dart";
+
+@Riverpod(keepAlive: true)
+Future<String> mapCacheDir(Ref ref) async {
+  final directory = await getTemporaryDirectory();
+  return directory.path;
+}
+
+@Riverpod(keepAlive: true)
+Future<DbCacheStore> mapCacheStore(Ref ref) async {
+  final directory = await ref.watch(mapCacheDirProvider.future);
+  return DbCacheStore(databaseName: MapCacheConfig.cacheDatabaseName, databasePath: directory);
+}

--- a/lib/features/navigator/navigation_controller.dart
+++ b/lib/features/navigator/navigation_controller.dart
@@ -1,126 +1,52 @@
 import "dart:async";
 
 import "package:auto_route/auto_route.dart";
-import "package:collection/collection.dart";
-import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
-import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../config/nav_bar_config.dart";
 import "app_router.dart";
+import "navigation_stack.dart";
 
 part "navigation_controller.g.dart";
 
 typedef TRoute = PageRouteInfo<dynamic>;
 
-typedef NavigationState = ({bool isStackPoppable, NavBarEnum activeTab, IList<TRoute> fullNavigationStack});
-
-@riverpod
-GlobalKey<AutoRouterState> navigatorKey(Ref ref) {
-  return GlobalKey<AutoRouterState>();
-}
-
 @riverpod
 class NavigationController extends _$NavigationController {
-  GlobalKey<AutoRouterState> get _navigatorKey => ref.watch(navigatorKeyProvider);
-
-  StackRouter? get _router => _navigatorKey.currentState?.controller;
-
-  Iterable<TRoute> get _stack => _router?.stackData.map((e) => e.route.toPageRouteInfo()) ?? [];
-
-  Future<void> keepTrackOfTabBarState(Future<void>? popFutureResults) async {
-    await Future.delayed(
-      Duration.zero,
-      refreshState, // refresh the state after the push
-    );
-    // await the route's pop
-    if (popFutureResults != null) await popFutureResults;
-    refreshState(); // refresh the state after the pop
-  }
+  StackRouter? get _router => state.currentState?.controller;
 
   Future<void> push(TRoute route) async {
-    final popFutureResults = _router?.push(route); // push the route
-    await keepTrackOfTabBarState(popFutureResults);
+    await _router?.push(route);
   }
 
+  // this manually handles deeplinks when they are launched within/inside the app
   Future<void> pushNamed(String uri) async {
-    final lastRoute = _fullStack.lastOrNull;
-    final isCurrentlyWithinTabView = ref
-        .read(appRouterProvider)
-        .routesWithinTabBar
-        .any((route) => route.name == lastRoute?.routeName);
-    final isDestinationWithinTabView = ref
-        .read(appRouterProvider)
-        .routesWithinTabBar
-        .any((route) => route.path.split("/").first == uri.split("/").first);
+    final lastRoute = ref.read(currentRouteProvider);
+    final routesWithinTabBar = ref.read(appRouterProvider).routesWithinTabBar;
+    final isCurrentlyWithinTabView = routesWithinTabBar.any((route) => route.name == lastRoute?.settings.name);
+    final isDestinationWithinTabView = routesWithinTabBar.any(
+      (route) => route.path.split("/").first == uri.split("/").first,
+    );
     final properlyWorkingURI = !isDestinationWithinTabView ? "/$uri" : uri;
-    final shouldPopBefore = !isCurrentlyWithinTabView && isDestinationWithinTabView;
-    if (shouldPopBefore) {
-      _popGlobalRouter();
+    final shouldPopBeforeNavigating = !isCurrentlyWithinTabView && isDestinationWithinTabView;
+    if (shouldPopBeforeNavigating) {
+      _router?.root.popUntil((element) => element.settings.name == RootRoute.name); // pop to root (tab bar view)
     }
-    final popFutureResults = _router?.pushPath(properlyWorkingURI); // push the route
-    await keepTrackOfTabBarState(popFutureResults);
+    await _router?.pushPath(properlyWorkingURI);
   }
 
   /// this is called only when you actually **click** in the nav tab bar
   /// so we don't call this on other navigation actions (like `Lista >` buttons)
   Future<void> onTabBarChange(NavBarEnum item) async {
     final route = NavBarConfig.tabViews[item]!;
-    if (_stack.last.routeName != route.routeName) {
-      _popUntilTabBarView();
+    if (_router?.stackData.last.route.name != route.routeName) {
       await push(route);
     }
   }
 
-  /// pops details views above tab views
-  void _popUntilTabBarView() {
-    _router?.popUntil(
-      (element) =>
-          element.settings is! AutoRoutePage ||
-          (element.settings as AutoRoutePage).routeData.topMatch.toPageRouteInfo().isTabView,
-    );
-  }
-
-  void _popGlobalRouter() {
-    _router?.root.popUntil(
-      (element) =>
-          element.settings is! AutoRoutePage ||
-          (element.settings as AutoRoutePage).routeData.topMatch.toPageRouteInfo().isRouteGlobalRoute,
-    );
-  }
-
-  void refreshState() {
-    state = build();
-  }
-
-  // so the problem is that we use both nested and global navigator and they have separate navigation stacks
-  List<TRoute> get _fullStack => [
-    ..._stack, // nested navigator stack
-    ..._router?.root.stackData
-            .map(
-              (e) => e.route.toPageRouteInfo(), // global navigator stack
-            )
-            .where((element) => !element.isRouteGlobalRoute) ??
-        [],
-  ]; // we spread both stacks to get proper combined stack
-
   @override
-  NavigationState build() {
-    return (
-      isStackPoppable: _stack.length > 1,
-      activeTab: _stack.lastWhereOrNull((element) => element.isTabView)?.tabBarEnum ?? NavBarEnum.home,
-      fullNavigationStack: _fullStack.toIList(),
-    );
+  GlobalKey<AutoRouterState> build() {
+    return GlobalKey<AutoRouterState>();
   }
-}
-
-@riverpod
-TRoute? previousRouteOnStack(Ref ref, String currentRouteName) {
-  final fullStack = ref.watch(navigationControllerProvider).fullNavigationStack;
-  final currentRouteIndex = fullStack.lastIndexWhere((element) => element.routeName == currentRouteName);
-  if (currentRouteIndex > 0) {
-    return fullStack[currentRouteIndex - 1];
-  }
-  return null;
 }

--- a/lib/features/navigator/navigation_stack.dart
+++ b/lib/features/navigator/navigation_stack.dart
@@ -1,0 +1,83 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+part "navigation_stack.g.dart";
+
+@Riverpod(keepAlive: true)
+class NavigationStack extends _$NavigationStack {
+  @override
+  IList<Route<dynamic>> build() {
+    return const IList.empty();
+  }
+
+  void setStack(IList<Route<dynamic>> value) {
+    state = value;
+  }
+}
+
+@riverpod
+Route<dynamic>? currentRoute(Ref ref) {
+  final stack = ref.watch(navigationStackProvider);
+  if (stack.isEmpty) {
+    return null;
+  }
+  return stack.last; // top most route
+}
+
+@riverpod
+Route<dynamic>? previousRoute(Ref ref) {
+  final stack = ref.watch(navigationStackProvider);
+  if (stack.length <= 1) {
+    return null;
+  }
+  return stack.removeLast().last; // second top most route
+}
+
+@riverpod
+bool isStackPoppable(Ref ref) {
+  return ref.watch(navigationStackProvider).length > 1;
+}
+
+/*
+  This class is used to observe the navigation stack
+  Acts as a bridge between navigator and riverpod state notifier
+*/
+class NavigationObserver extends NavigatorObserver {
+  final WidgetRef ref;
+
+  NavigationObserver(this.ref);
+
+  /*
+  This 2 methods sync observer with the riverpod state
+  */
+  void setStack(IList<Route<dynamic>> value) {
+    Future.microtask(() => ref.read(navigationStackProvider.notifier).setStack(value));
+  }
+
+  IList<Route<dynamic>> get stack => ref.read(navigationStackProvider);
+
+  /*
+  This 4 methods sync observer with the actual navigation stack
+  */
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    setStack(stack.removeLast());
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    setStack(stack.add(route));
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    setStack(stack.removeLast().add(newRoute!));
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    setStack(stack.removeLast());
+  }
+}

--- a/lib/features/navigator/root_view.dart
+++ b/lib/features/navigator/root_view.dart
@@ -22,10 +22,8 @@ class RootView extends ConsumerWidget {
         child: UpdateChangelogWrapper(
           child: HorizontalSymmetricSafeAreaScaffold(
             bottomNavigationBar: const BottomNavBar(),
-            body: AutoRouter(
-              // this widget acts as nested [Navigator] for the app
-              key: ref.watch(navigatorKeyProvider),
-            ),
+            // this widget acts as nested [Navigator] for the app
+            body: AutoRouter(key: ref.watch(navigationControllerProvider)),
           ),
         ),
       ),

--- a/lib/features/navigator/utils/android_pop_bug_workaround.dart
+++ b/lib/features/navigator/utils/android_pop_bug_workaround.dart
@@ -5,13 +5,13 @@ import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
-import "../navigation_controller.dart";
+import "../navigation_stack.dart";
 
 extension AndroidPopBugWorkaroundX on WidgetRef {
   static const platform = MethodChannel("topwr.app.android.channel");
 
   bool get androidSpecialPopTreatment {
-    return !kIsWeb && Platform.isAndroid && !read(navigationControllerProvider).isStackPoppable;
+    return !kIsWeb && Platform.isAndroid && !read(isStackPoppableProvider);
   }
 
   Future<void> handleAndroidSpecialPop() async {

--- a/lib/features/parkings/parking_chart/models/chart_point.dart
+++ b/lib/features/parkings/parking_chart/models/chart_point.dart
@@ -1,4 +1,5 @@
 import "dart:math" as math;
+
 import "package:collection/collection.dart";
 import "package:fl_chart/fl_chart.dart";
 

--- a/lib/features/parkings/parkings_view/repository/parkings_repository.dart
+++ b/lib/features/parkings/parkings_view/repository/parkings_repository.dart
@@ -14,7 +14,6 @@ import "../../../../utils/ref_extensions.dart";
 import "../api_client/iparking_client.dart";
 import "../api_client/iparking_commands.dart";
 import "../models/parking.dart";
-
 import "local_fav_parking_repository.dart";
 
 part "parkings_repository.g.dart";

--- a/lib/features/splash_screen/splash_screen_controller.dart
+++ b/lib/features/splash_screen/splash_screen_controller.dart
@@ -9,6 +9,7 @@ import "../../api_base/hive_init.dart";
 import "../../config/ui_config.dart";
 import "../../firebase_init.dart";
 import "../home_view/widgets/logo_app_bar.dart";
+import "../map_view/data/cache.dart";
 
 part "splash_screen_controller.g.dart";
 
@@ -23,6 +24,7 @@ class SplashScreenController extends _$SplashScreenController {
     await firebaseInit();
     await initHiveForGraphqlCache();
     await AppBarLogo.precacheImageIfAbsent();
+    await ref.read(mapCacheStoreProvider.future); // prefetch map cache directory
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:wiredash/wiredash.dart";
@@ -9,7 +8,7 @@ import "config/ui_config.dart";
 import "config/wiredash.dart";
 import "features/in_app_review/presentation/in_app_review.dart";
 import "features/navigator/app_router.dart";
-import "features/navigator/navigation_controller.dart";
+import "features/navigator/navigation_stack.dart";
 import "features/splash_screen/splash_screen.dart";
 import "features/splash_screen/splash_screen_controller.dart";
 import "features/update_dialog/presentation/update_dialog_wrapper.dart";
@@ -54,17 +53,7 @@ class MyApp extends ConsumerWidget {
               ),
             ),
             debugShowCheckedModeBanner: false,
-            routerConfig: ref
-                .watch(appRouterProvider)
-                .config(
-                  deepLinkTransformer: (uri) {
-                    Future.delayed(
-                      const Duration(milliseconds: 500),
-                      ref.read(navigationControllerProvider.notifier).refreshState,
-                    ); // TODO(simon-the-shark): remove this nasty workaround for active tab refresh
-                    return SynchronousFuture(uri);
-                  },
-                ),
+            routerConfig: ref.watch(appRouterProvider).config(navigatorObservers: () => [NavigationObserver(ref)]),
           ),
         ),
       ),

--- a/lib/services/translations_service/data/data_source/local/database/translations_database.dart
+++ b/lib/services/translations_service/data/data_source/local/database/translations_database.dart
@@ -4,6 +4,7 @@ import "package:drift_flutter/drift_flutter.dart";
 import "../../../models/supported_languages.dart";
 import "../../../models/translation.dart";
 import "../translations_data_source.dart";
+
 part "translations_database.g.dart";
 
 @DriftDatabase(tables: [Translations])

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+
 import "hex_color.dart";
 
 abstract class ColorsConsts {

--- a/lib/utils/ref_extensions.dart
+++ b/lib/utils/ref_extensions.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 extension RefIntervalRefreshX on Ref {

--- a/lib/utils/shared_prefs_extensions.dart
+++ b/lib/utils/shared_prefs_extensions.dart
@@ -1,4 +1,5 @@
 import "package:shared_preferences/shared_preferences.dart";
+
 import "timestamp.dart";
 
 extension SharedPreferencesX on SharedPreferences {

--- a/lib/widgets/detail_views/pop_button.dart
+++ b/lib/widgets/detail_views/pop_button.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../config/nav_bar_config.dart";
-import "../../features/navigator/navigation_controller.dart";
+import "../../features/navigator/navigation_stack.dart";
 import "../../services/translations_service/widgets/text_with_translation.dart";
 import "../../theme/app_theme.dart";
 
@@ -10,11 +10,7 @@ class DetailViewPopButton extends ConsumerWidget {
   const DetailViewPopButton({super.key});
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentRoute = ModalRoute.of(context)?.settings.name;
-    final title =
-        currentRoute == null
-            ? null
-            : ref.watch(previousRouteOnStackProvider(currentRoute))?.getFormatedRouteName(context);
+    final title = ref.watch(previousRouteProvider)?.getFormattedRouteName(context);
 
     return TextButton(
       onPressed: () {

--- a/lib/widgets/loading_widgets/contact_section_loading.dart
+++ b/lib/widgets/loading_widgets/contact_section_loading.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+
 import "../../config/ui_config.dart";
 import "../../theme/app_theme.dart";
 import "shimmer_loading.dart";

--- a/lib/widgets/loading_widgets/specific_imitations/button_loading.dart
+++ b/lib/widgets/loading_widgets/specific_imitations/button_loading.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+
 import "../shimmer_loading.dart";
 
 class ButtonLoading extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,10 +55,10 @@ dependencies:
   hive: ^2.2.3
   shared_preferences: ^2.5.2
   cached_network_image: ^3.4.1
-  dio_cache_interceptor_hive_store: ^4.0.0
   flutter_cache_manager: ^3.4.1
   drift: ^2.26.0
   drift_flutter: ^0.2.4
+  dio_cache_interceptor_db_store: ^6.0.0
 
   #Network
   url_launcher: ^6.3.1


### PR DESCRIPTION
so the bottom nav bar was broken after last beta update.
I didn't get into details of it, just reorganized it all a little. Now the navigation logic should have less "custom logic" and more let's say "standard". Though it's far from fully standard, but I've tried to keep as much of our custom behaviour as possible but with a little bit simpler code (but it's literally the same amount of lines). Now instead of werid "fiku miku with awaiting" we just use flutter's built int `NavigationObserver` and sync them with riverpod to be able to write some logic based on navigation state. I probably should've done that from the begginging but it's always seemed lenghty for me
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor navigation to use Flutter's `NavigationObserver` and Riverpod for improved reliability and simplicity.
> 
>   - **Navigation Refactor**:
>     - Replaces custom navigation logic with Flutter's `NavigationObserver` in `navigation_stack.dart`.
>     - Integrates navigation state with Riverpod in `navigation_controller.dart`.
>     - Adds `bottom_nav_bar_controller.dart` to manage active tab state using Riverpod.
>   - **Code Cleanup**:
>     - Removes unused imports in `nav_bar_config.dart` and `bottom_nav_bar.dart`.
>     - Reorganizes imports in `controllers.dart` and `toilet.dart`.
>     - Fixes minor formatting issues in `translations_database.dart` and `colors.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for f6a9cb4a099db389085caf5bb76fe5eec12dfdc8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->