### PR TITLE
fix: animation shown when returning from tab

### DIFF
--- a/lib/features/navigator/app_router.dart
+++ b/lib/features/navigator/app_router.dart
@@ -54,7 +54,7 @@ part "app_router.gr.dart";
 
 class _NoTransitionRoute extends CustomRoute<void> {
   _NoTransitionRoute({required super.path, required super.page})
-    : super(reverseDuration: Duration.zero, duration: Duration.zero);
+    : super(reverseDuration: Duration.zero, duration: Duration.zero, allowSnapshotting: false);
 }
 
 @AutoRouterConfig(replaceInRouteName: "View,Route")

--- a/lib/widgets/horizontal_symmetric_safe_area.dart
+++ b/lib/widgets/horizontal_symmetric_safe_area.dart
@@ -1,6 +1,9 @@
 import "dart:math";
 
 import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../features/navigator/navigation_stack.dart";
 
 extension MediaQueryPaddingExtensionX on BuildContext {
   EdgeInsets get maxOfHorizontalViewPaddings {
@@ -10,15 +13,17 @@ extension MediaQueryPaddingExtensionX on BuildContext {
   }
 }
 
-class HorizontalSymmetricSafeArea extends StatelessWidget {
+class HorizontalSymmetricSafeArea extends ConsumerWidget {
   const HorizontalSymmetricSafeArea({super.key, required this.child});
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentRoute = ref.watch(currentRouteProvider)?.settings.name;
+    final isMapView = currentRoute == "BuildingsRoute" || currentRoute == "ParkingsRoute";
     return Padding(
       padding: context.maxOfHorizontalViewPaddings,
-      child: SafeArea(left: false, right: false, child: child),
+      child: SafeArea(left: false, right: false, top: !isMapView, child: child),
     );
   }
 }


### PR DESCRIPTION
random solution from reddit but seems to work and fix #500 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes animation issue when returning from a tab by setting `allowSnapshotting: false` in `_NoTransitionRoute` in `app_router.dart`.
> 
>   - **Behavior**:
>     - Fixes animation issue when returning from a tab by setting `allowSnapshotting: false` in `_NoTransitionRoute` in `app_router.dart`.
>   - **Misc**:
>     - References issue #500 in the commit message.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 9015aaed0337283192f20122a9f846063fe8d94e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->