### PR TITLE
fix(map): remove top safe area

### DIFF
--- a/lib/widgets/horizontal_symmetric_safe_area.dart
+++ b/lib/widgets/horizontal_symmetric_safe_area.dart
@@ -1,6 +1,9 @@
 import "dart:math";
 
 import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../features/navigator/navigation_stack.dart";
 
 extension MediaQueryPaddingExtensionX on BuildContext {
   EdgeInsets get maxOfHorizontalViewPaddings {
@@ -10,15 +13,17 @@ extension MediaQueryPaddingExtensionX on BuildContext {
   }
 }
 
-class HorizontalSymmetricSafeArea extends StatelessWidget {
+class HorizontalSymmetricSafeArea extends ConsumerWidget {
   const HorizontalSymmetricSafeArea({super.key, required this.child});
   final Widget child;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentRoute = ref.watch(currentRouteProvider)?.settings.name;
+    final isMapView = currentRoute == "BuildingsRoute" || currentRoute == "ParkingsRoute";
     return Padding(
       padding: context.maxOfHorizontalViewPaddings,
-      child: SafeArea(left: false, right: false, child: child),
+      child: SafeArea(left: false, right: false, top: !isMapView, child: child),
     );
   }
 }


### PR DESCRIPTION
# before
<img width="464" alt="Zrzut ekranu 2025-04-4 o 23 54 34" src="https://github.com/user-attachments/assets/e97f04a8-a38f-4648-bda2-b8734f6ab486" />
# after 
<img width="484" alt="Zrzut ekranu 2025-04-4 o 23 58 29" src="https://github.com/user-attachments/assets/9f3e79f5-dc6f-4790-99cb-b0ee7c844b45" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `HorizontalSymmetricSafeArea` now conditionally removes top safe area padding for specific routes using Riverpod.
> 
>   - **Behavior**:
>     - `HorizontalSymmetricSafeArea` now conditionally removes top safe area padding for `BuildingsRoute` and `ParkingsRoute`.
>     - Uses `Riverpod` to determine the current route.
>   - **Classes**:
>     - Change `HorizontalSymmetricSafeArea` from `StatelessWidget` to `ConsumerWidget`.
>     - Add `currentRoute` logic in `build()` method to check route name.
>   - **Imports**:
>     - Add `flutter_riverpod` and `navigation_stack.dart` imports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for a4ef94320314e3b691df775ab68bd015908bae4c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->