### PR TITLE
refactor: change from watch to read in parkings

### DIFF
--- a/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
@@ -15,7 +15,9 @@ class FavouriteParkingWidget extends ConsumerWidget {
 
     return IconButton(
       visualDensity: VisualDensity.compact,
-      onPressed: ref.read(localFavParkingsRepositoryProvider(parking.id).notifier).toggle,
+      onPressed: () async {
+        await ref.read(localFavParkingsRepositoryProvider(parking.id).notifier).toggle();
+      },
       icon:
           isFavorite == null
               ? FavouriteIcon(icon: Icons.error, color: context.colorTheme.whiteSoap)

--- a/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
@@ -12,7 +12,7 @@ class FavouriteParkingWidget extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final isFavorite = ref.watch(localFavParkingsRepositoryProvider(parking.id));
-    
+
     return IconButton(
       visualDensity: VisualDensity.compact,
       onPressed: ref.read(localFavParkingsRepositoryProvider(parking.id).notifier).toggle,

--- a/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
@@ -11,11 +11,11 @@ class FavouriteParkingWidget extends ConsumerWidget {
   final Parking parking;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final favController = ref.read(localFavParkingsRepositoryProvider(parking.id).notifier);
     final isFavorite = ref.watch(localFavParkingsRepositoryProvider(parking.id));
+    
     return IconButton(
       visualDensity: VisualDensity.compact,
-      onPressed: favController.toggle,
+      onPressed: ref.read(localFavParkingsRepositoryProvider(parking.id).notifier).toggle,
       icon:
           isFavorite == null
               ? FavouriteIcon(icon: Icons.error, color: context.colorTheme.whiteSoap)

--- a/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_favourite.dart
@@ -11,7 +11,7 @@ class FavouriteParkingWidget extends ConsumerWidget {
   final Parking parking;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final favController = ref.watch(localFavParkingsRepositoryProvider(parking.id).notifier);
+    final favController = ref.read(localFavParkingsRepositoryProvider(parking.id).notifier);
     final isFavorite = ref.watch(localFavParkingsRepositoryProvider(parking.id));
     return IconButton(
       visualDensity: VisualDensity.compact,


### PR DESCRIPTION
While I was doing onboarding I had seen this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `FavouriteParkingWidget` to use `ref.read` instead of `ref.watch` for toggling favorite status to avoid unnecessary rebuilds.
> 
>   - **Refactor**:
>     - In `FavouriteParkingWidget`, change from `ref.watch` to `ref.read` for `localFavParkingsRepositoryProvider(parking.id).notifier` in `onPressed` callback to avoid unnecessary rebuilds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 4ce92f45a5d6f85e6ffd9aa80e46da8318cd0b34. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->