### PR TITLE
fix(parkings): distinct chart labels

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -121,6 +121,7 @@ abstract class ParkingsConfig {
 
 abstract class ParkingChartConfig {
   static final showLabels = generateRangeHourPoints(6, 22).toList();
+  static const labelFontSize = 16.0;
 }
 
 abstract class AboutUsConfig {

--- a/lib/features/parkings/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parkings/parking_chart/widgets/chart_widget.dart
@@ -2,6 +2,7 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:fl_chart/fl_chart.dart";
 import "package:flutter/material.dart";
 
+import "../../../../config/ui_config.dart";
 import "../../../../theme/app_theme.dart";
 import "../../../../widgets/charts/hide_labels.dart";
 import "../../parkings_view/models/parking.dart";
@@ -50,7 +51,11 @@ class ChartWidget extends StatelessWidget {
                       final value = touchedSpot.y.toInt().toString();
                       return LineTooltipItem(
                         "$value\n",
-                        TextStyle(color: context.colorTheme.whiteSoap, fontWeight: FontWeight.bold),
+                        TextStyle(
+                          color: context.colorTheme.whiteSoap,
+                          fontWeight: FontWeight.bold,
+                          fontSize: ParkingChartConfig.labelFontSize,
+                        ),
                         children: [
                           TextSpan(
                             text: hour,

--- a/lib/features/parkings/parking_chart/widgets/chart_widget.dart
+++ b/lib/features/parkings/parking_chart/widgets/chart_widget.dart
@@ -47,10 +47,16 @@ class ChartWidget extends StatelessWidget {
                   getTooltipItems: (touchedSpots) {
                     return touchedSpots.map((touchedSpot) {
                       final hour = HourLabel(touchedSpot.x).toStringRepr();
-                      final value = touchedSpot.y.toInt(); // Convert double to int
+                      final value = touchedSpot.y.toInt().toString();
                       return LineTooltipItem(
-                        "$value\n$hour",
+                        "$value\n",
                         TextStyle(color: context.colorTheme.whiteSoap, fontWeight: FontWeight.bold),
+                        children: [
+                          TextSpan(
+                            text: hour,
+                            style: TextStyle(color: context.colorTheme.greyLight, fontWeight: FontWeight.normal),
+                          ),
+                        ],
                       );
                     }).toList();
                   },


### PR DESCRIPTION
this is what you ment? i tried different colors - blue or pigeon grey but it's too similar to the background imo 
![Zrzut ekranu 2025-04-13 170434](https://github.com/user-attachments/assets/fb1fd8cc-7f74-4d59-81a6-b31f415bd5d9)


the pigeon grey looked like this: 
![Zrzut ekranu 2025-04-13 170525](https://github.com/user-attachments/assets/0924539d-1c5b-4eed-8884-b21079f22573)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjusts parking chart tooltip label font size and color for better distinction in `ChartWidget`.
> 
>   - **Behavior**:
>     - Adjusts tooltip label font size in `ChartWidget` to `ParkingChartConfig.labelFontSize`.
>     - Changes tooltip label color to `context.colorTheme.whiteSoap` and hour text to `context.colorTheme.greyLight`.
>   - **Config**:
>     - Adds `labelFontSize` constant to `ParkingChartConfig` in `ui_config.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 7f55b69bb4e5ffe28fc1373b4d18b44a14d891e1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->