### PR TITLE
feat(home-screen-banner): adjust paddings #661

### DIFF
--- a/lib/features/planner_advert/widgets/planner_advert_widget.dart
+++ b/lib/features/planner_advert/widgets/planner_advert_widget.dart
@@ -16,14 +16,11 @@ class PlannerAdvertBanner extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(plannerAdvertContentRepositoryProvider);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingMedium),
-      child: switch (state) {
-        AsyncError(:final error) => MyErrorWidget(error),
-        AsyncValue(:final PlannerAdvertContent value) => _PlannerAdvertBanner(value),
-        _ => const HorizontalRectangularSectionLoading(),
-      },
-    );
+    return switch (state) {
+      AsyncError(:final error) => MyErrorWidget(error),
+      AsyncValue(:final PlannerAdvertContent value) => _PlannerAdvertBanner(value),
+      _ => const HorizontalRectangularSectionLoading(),
+    };
   }
 }
 

--- a/lib/features/planner_advert/widgets/planner_advert_widget.dart
+++ b/lib/features/planner_advert/widgets/planner_advert_widget.dart
@@ -16,11 +16,14 @@ class PlannerAdvertBanner extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(plannerAdvertContentRepositoryProvider);
-    return switch (state) {
-      AsyncError(:final error) => MyErrorWidget(error),
-      AsyncValue(:final PlannerAdvertContent value) => _PlannerAdvertBanner(value),
-      _ => const HorizontalRectangularSectionLoading(),
-    };
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingMedium),
+      child: switch (state) {
+        AsyncError(:final error) => MyErrorWidget(error),
+        AsyncValue(:final PlannerAdvertContent value) => _PlannerAdvertBanner(value),
+        _ => const HorizontalRectangularSectionLoading(),
+      },
+    );
   }
 }
 

--- a/lib/widgets/loading_widgets/simple_previews/horizontal_rectangular_section_loading.dart
+++ b/lib/widgets/loading_widgets/simple_previews/horizontal_rectangular_section_loading.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 
+import "../../../config/ui_config.dart";
 import "../shimmer_loading.dart";
 
 class HorizontalRectangularSectionLoading extends StatelessWidget {
@@ -7,11 +8,20 @@ class HorizontalRectangularSectionLoading extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ShimmeringEffect(
-      child: Container(
-        width: double.maxFinite,
-        height: 69,
-        decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(8)),
+    return Padding(
+      padding: const EdgeInsets.only(top: HomeViewConfig.paddingMedium),
+      child: ShimmeringEffect(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingMedium),
+          child: Container(
+            width: double.maxFinite,
+            height: 69,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(AppWidgetsConfig.borderRadiusMedium),
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
fix-up the shimmer loading for the banner on Home Screen for advertising Planer
<img width="365" alt="Screenshot 2025-04-16 at 15 21 50" src="https://github.com/user-attachments/assets/ce9cdaec-1682-476c-8301-96dffe2b3eec" />
