### PR TITLE
feat: accessibility for about us screen

### DIFF
--- a/lib/features/about_us_view/utils/custom_license_dialog.dart
+++ b/lib/features/about_us_view/utils/custom_license_dialog.dart
@@ -63,9 +63,10 @@ class _DialogContent extends StatelessWidget {
                   applicationName,
                   style: const TextStyle(fontWeight: FontWeight.w500, fontSize: AboutUsConfig.dialogTitleFontSize),
                 ),
-                Semantics(
-                  label: "${context.localize.version} ${applicationVersion.replaceAll(".", " ")}",
-                  child: Text(applicationVersion, style: context.textTheme.lightTitle),
+                Text(
+                  applicationVersion,
+                  style: context.textTheme.lightTitle,
+                  semanticsLabel: "${context.localize.version} ${applicationVersion.replaceAll(".", " ")}",
                 ),
               ],
             ),

--- a/lib/features/about_us_view/utils/custom_license_dialog.dart
+++ b/lib/features/about_us_view/utils/custom_license_dialog.dart
@@ -63,7 +63,10 @@ class _DialogContent extends StatelessWidget {
                   applicationName,
                   style: const TextStyle(fontWeight: FontWeight.w500, fontSize: AboutUsConfig.dialogTitleFontSize),
                 ),
-                Text(applicationVersion, style: context.textTheme.lightTitle),
+                Semantics(
+                  label: "${context.localize.version} ${applicationVersion.replaceAll(".", " ")}",
+                  child: Text(applicationVersion, style: context.textTheme.lightTitle),
+                ),
               ],
             ),
             applicationIcon,

--- a/lib/features/about_us_view/widgets/app_version.dart
+++ b/lib/features/about_us_view/widgets/app_version.dart
@@ -17,18 +17,26 @@ class AppVersionTile extends StatelessWidget {
       child: FutureBuilder(
         future: Future.microtask(PackageInfo.fromPlatform),
         builder:
-            (context, snapshot) => ListTile(
-              title: Text(
-                "${MyAppConfig.title} ${snapshot.data?.version} ${context.localize.app_info}",
-                style: context.textTheme.bodyGrey,
+            (context, snapshot) => Semantics(
+              label:
+                  "${context.localize.version} ${snapshot.data?.version.replaceAll(".", " ")} ${context.localize.app_info}",
+              child: ListTile(
+                title: ExcludeSemantics(
+                  child: Text(
+                    "${MyAppConfig.title} ${snapshot.data?.version} ${context.localize.app_info}",
+                    style: context.textTheme.bodyGrey,
+                  ),
+                ),
+                leading: ExcludeSemantics(
+                  child: Icon(Icons.info, color: context.colorTheme.orangePomegranade, size: 22),
+                ),
+                contentPadding: const EdgeInsets.symmetric(horizontal: WideTileCardConfig.basePadding),
+                horizontalTitleGap: 8,
+                onTap: () async {
+                  // TODO(simon-the-shark): customize [LicensePage] theme
+                  await showMyLicenceDialog(context, snapshot.data?.version);
+                },
               ),
-              leading: Icon(Icons.info, color: context.colorTheme.orangePomegranade, size: 22),
-              contentPadding: const EdgeInsets.symmetric(horizontal: WideTileCardConfig.basePadding),
-              horizontalTitleGap: 8,
-              onTap: () async {
-                // TODO(simon-the-shark): customize [LicensePage] theme
-                await showMyLicenceDialog(context, snapshot.data?.version);
-              },
             ),
       ),
     );

--- a/lib/features/about_us_view/widgets/contact_section.dart
+++ b/lib/features/about_us_view/widgets/contact_section.dart
@@ -5,6 +5,7 @@ import "package:flutter_svg/svg.dart";
 
 import "../../../config/ui_config.dart";
 import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "../../../utils/determine_contact_icon.dart";
 import "../../../utils/launch_url_util.dart";
 
@@ -33,16 +34,21 @@ class _ContactIcon extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return GestureDetector(
-      onTap: () async => ref.launch(url),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: context.colorTheme.greyLight,
-          borderRadius: BorderRadius.circular(AboutUsConfig.borderRadius),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(AboutUsConfig.iconPadding),
-          child: Center(child: SvgPicture.asset(icon)),
+    return Semantics(
+      label: "${context.localize.button_leading_to}: ${url.substring(7)}",
+      child: GestureDetector(
+        onTap: () async => ref.launch(url),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: context.colorTheme.greyLight,
+            borderRadius: BorderRadius.circular(AboutUsConfig.borderRadius),
+          ),
+          child: ExcludeSemantics(
+            child: Padding(
+              padding: const EdgeInsets.all(AboutUsConfig.iconPadding),
+              child: Center(child: SvgPicture.asset(icon)),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/about_us_view/widgets/contact_section.dart
+++ b/lib/features/about_us_view/widgets/contact_section.dart
@@ -35,7 +35,7 @@ class _ContactIcon extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Semantics(
-      label: "${context.localize.button_leading_to}: ${url.substring(7)}",
+      label: "${context.localize.button_leading_to}: ${Uri.parse(url).host}}",
       child: GestureDetector(
         onTap: () async => ref.launch(url),
         child: DecoratedBox(

--- a/lib/features/about_us_view/widgets/contact_section.dart
+++ b/lib/features/about_us_view/widgets/contact_section.dart
@@ -35,7 +35,7 @@ class _ContactIcon extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Semantics(
-      label: "${context.localize.button_leading_to}: ${Uri.parse(url).host}}",
+      label: "${context.localize.button_leading_to}: ${Uri.parse(url).host}",
       child: GestureDetector(
         onTap: () async => ref.launch(url),
         child: DecoratedBox(

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -60,17 +60,13 @@ class _SelectTab extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 7),
       child: Center(
-        child: Semantics(
-          label: "${context.localize.version}: ${version.versionName.replaceAll(".", " ")}",
-          child: ExcludeSemantics(
-            child: Text(
-              version.versionName,
-              style:
-                  isSelected
-                      ? context.textTheme.boldBody.copyWith(color: context.colorTheme.whiteSoap)
-                      : context.textTheme.boldBody,
-            ),
-          ),
+        child: Text(
+          semanticsLabel: "${context.localize.version}: ${version.versionName.replaceAll(".", " ")}",
+          version.versionName,
+          style:
+              isSelected
+                  ? context.textTheme.boldBody.copyWith(color: context.colorTheme.whiteSoap)
+                  : context.textTheme.boldBody,
         ),
       ),
     );

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -180,17 +180,16 @@ class _TeamMemberCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: WideTileCardConfig.imageSize,
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 8),
-        child: Container(
-          width: double.infinity,
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
-            color: context.colorTheme.greyLight,
-            borderRadius: BorderRadius.circular(AboutUsConfig.borderRadius),
-          ),
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Container(
+        width: double.infinity,
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: context.colorTheme.greyLight,
+          borderRadius: BorderRadius.circular(AboutUsConfig.borderRadius),
+        ),
+        child: IntrinsicHeight(
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -201,7 +200,9 @@ class _TeamMemberCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 14),
-              _Description(name: member.name ?? "", subtitle: member.subtitle ?? "", links: member.links),
+              Flexible(
+                child: _Description(name: member.name ?? "", subtitle: member.subtitle ?? "", links: member.links),
+              ),
             ],
           ),
         ),
@@ -239,24 +240,28 @@ class _Description extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Text(name, style: context.aboutUsTheme.headlineSmaller),
-        const SizedBox(height: 4),
-        Text(subtitle, style: context.aboutUsTheme.bodySmaller),
-        const SizedBox(height: 8),
-        Row(
+    return Expanded(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            for (final icon in links)
-              Semantics(
-                label: "${context.localize.button_leading_to}: ${icon.url?.substring(7)}",
-                child: _Icon(launchUrl: icon.url ?? "", icon: icon.icon),
-              ),
+            Text(name, style: context.aboutUsTheme.headlineSmaller, softWrap: true),
+            const SizedBox(height: 4),
+            Text(subtitle, style: context.aboutUsTheme.bodySmaller, softWrap: true),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                for (final icon in links)
+                  Semantics(
+                    label: "${context.localize.button_leading_to}: ${Uri.parse(icon.url ?? "").host}",
+                    child: _Icon(launchUrl: icon.url ?? "", icon: icon.icon),
+                  ),
+              ],
+            ),
           ],
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -60,12 +60,17 @@ class _SelectTab extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 7),
       child: Center(
-        child: Text(
-          version.versionName,
-          style:
-              isSelected
-                  ? context.textTheme.boldBody.copyWith(color: context.colorTheme.whiteSoap)
-                  : context.textTheme.boldBody,
+        child: Semantics(
+          label: "${context.localize.version}: ${version.versionName.replaceAll(".", " ")}",
+          child: ExcludeSemantics(
+            child: Text(
+              version.versionName,
+              style:
+                  isSelected
+                      ? context.textTheme.boldBody.copyWith(color: context.colorTheme.whiteSoap)
+                      : context.textTheme.boldBody,
+            ),
+          ),
         ),
       ),
     );
@@ -189,9 +194,11 @@ class _TeamMemberCard extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              SizedBox.square(
-                dimension: AboutUsConfig.photoSize,
-                child: ZoomableOptimizedDirectusImage(member.directusImageUrl),
+              ExcludeSemantics(
+                child: SizedBox.square(
+                  dimension: AboutUsConfig.photoSize,
+                  child: ZoomableOptimizedDirectusImage(member.directusImageUrl),
+                ),
               ),
               const SizedBox(width: 14),
               _Description(name: member.name ?? "", subtitle: member.subtitle ?? "", links: member.links),
@@ -240,7 +247,15 @@ class _Description extends StatelessWidget {
         const SizedBox(height: 4),
         Text(subtitle, style: context.aboutUsTheme.bodySmaller),
         const SizedBox(height: 8),
-        Row(children: [for (final icon in links) _Icon(launchUrl: icon.url ?? "", icon: icon.icon)]),
+        Row(
+          children: [
+            for (final icon in links)
+              Semantics(
+                label: "${context.localize.button_leading_to}: ${icon.url?.substring(7)}",
+                child: _Icon(launchUrl: icon.url ?? "", icon: icon.icon),
+              ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -488,5 +488,6 @@
   "parking_are_spaces_for_pwd": "{boolean, select, true{There are designated parking spaces for people with disabilities. Number of available spaces: } false{There are no designated parking spaces for people with disabilities. } other{}}",
   "parking_are_spaces_for_pwd_vertical_marked": "{boolean, select, true{Parking spaces for people with disabilities are marked with vertical signs.} false{Parking spaces for people with disabilities are not marked with vertical signs.} other{}}",  "is_multistorey_parking": "The parking lot is {boolean, select, true{multistorey. } other{single-storey. }}",
   "parking_is_road_accessible_for_people_in_wheelchairs": "{boolean, select, true{The road from the parking space for people with disabilities to the building or elevator is accessible. } false{The road from the parking space for people with disabilities to the elevator is not accessible. } other{}}",
-  "parking_shortest_length_to_nearest_spaces_for_pwd": "The entrance to the building or elevator in the underground parking lot is located {value} meters from the parking space for people with disabilities."
+  "parking_shortest_length_to_nearest_spaces_for_pwd": "The entrance to the building or elevator in the underground parking lot is located {value} meters from the parking space for people with disabilities.",
+  "button_leading_to": "Button leading to"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -489,5 +489,6 @@
   "parking_are_spaces_for_pwd_vertical_marked": "{boolean, select, true{Parking spaces for people with disabilities are marked with vertical signs.} false{Parking spaces for people with disabilities are not marked with vertical signs.} other{}}",  "is_multistorey_parking": "The parking lot is {boolean, select, true{multistorey. } other{single-storey. }}",
   "parking_is_road_accessible_for_people_in_wheelchairs": "{boolean, select, true{The road from the parking space for people with disabilities to the building or elevator is accessible. } false{The road from the parking space for people with disabilities to the elevator is not accessible. } other{}}",
   "parking_shortest_length_to_nearest_spaces_for_pwd": "The entrance to the building or elevator in the underground parking lot is located {value} meters from the parking space for people with disabilities.",
-  "button_leading_to": "Button leading to"
+  "button_leading_to": "Button leading to",
+  "logotype": "Logotype"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3069,6 +3069,11 @@
         "type": "num"
       }
     }
+  },
+
+  "button_leading_to": "Przycisk prowadzący do",
+  "@button_leading_to":{
+    "description": "information about url the button is redirecting to"
   }
   
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3074,6 +3074,10 @@
   "button_leading_to": "Przycisk prowadzący do",
   "@button_leading_to":{
     "description": "information about url the button is redirecting to"
+  },
+  "logotype": "Logotyp",
+  "@logotype":{
+    "description": "information about some logotype"
   }
   
 }

--- a/lib/utils/html_to_plain_text.dart
+++ b/lib/utils/html_to_plain_text.dart
@@ -1,0 +1,8 @@
+import "package:html/parser.dart";
+
+extension HtmlToPlainTextX on String {
+  String parseHtmlString() {
+    final String parsedString = parse(this).documentElement?.text ?? "";
+    return parsedString;
+  }
+}

--- a/lib/widgets/detail_views/sliver_header_section.dart
+++ b/lib/widgets/detail_views/sliver_header_section.dart
@@ -3,6 +3,7 @@ import "dart:math";
 import "package:flutter/material.dart";
 
 import "../../config/ui_config.dart";
+import "../../utils/context_extensions.dart";
 import "../zoomable_images.dart";
 import "sliver_logo.dart";
 
@@ -38,10 +39,11 @@ class SliverHeaderSection extends SliverPersistentHeaderDelegate {
     final logoSize = calcLogoSize(shrinkOffset);
     final logoOpacity = calcLogoOpacity(shrinkOffset, logoSize);
     final scaleFactor = activeGradient != null ? 0.5 : 1.0;
-    return ExcludeSemantics(
-      child: Stack(
-        children: [
-          Opacity(
+
+    return Stack(
+      children: [
+        ExcludeSemantics(
+          child: Opacity(
             opacity: 1 - progress,
             child: SizedBox(
               height: maxTopBarHeight * (1 - progress),
@@ -49,16 +51,23 @@ class SliverHeaderSection extends SliverPersistentHeaderDelegate {
               child: ZoomableOptimizedDirectusImage(backgroundImageUrl),
             ),
           ),
-          SliverLogo(
-            scaleFactor: scaleFactor,
-            activeGradient: activeGradient,
-            logoDirectusUrl: logoDirectusImageUrl,
-            logoOpacity: logoOpacity,
-            logoSize: logoSize,
-            boxfit: BoxFit.scaleDown,
+        ),
+        Semantics(
+          label: context.localize.logotype,
+          image: true,
+          button: false,
+          child: ExcludeSemantics(
+            child: SliverLogo(
+              scaleFactor: scaleFactor,
+              activeGradient: activeGradient,
+              logoDirectusUrl: logoDirectusImageUrl,
+              logoOpacity: logoOpacity,
+              logoSize: logoSize,
+              boxfit: BoxFit.scaleDown,
+            ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/lib/widgets/detail_views/sliver_header_section.dart
+++ b/lib/widgets/detail_views/sliver_header_section.dart
@@ -38,25 +38,27 @@ class SliverHeaderSection extends SliverPersistentHeaderDelegate {
     final logoSize = calcLogoSize(shrinkOffset);
     final logoOpacity = calcLogoOpacity(shrinkOffset, logoSize);
     final scaleFactor = activeGradient != null ? 0.5 : 1.0;
-    return Stack(
-      children: [
-        Opacity(
-          opacity: 1 - progress,
-          child: SizedBox(
-            height: maxTopBarHeight * (1 - progress),
-            width: double.infinity,
-            child: ZoomableOptimizedDirectusImage(backgroundImageUrl),
+    return ExcludeSemantics(
+      child: Stack(
+        children: [
+          Opacity(
+            opacity: 1 - progress,
+            child: SizedBox(
+              height: maxTopBarHeight * (1 - progress),
+              width: double.infinity,
+              child: ZoomableOptimizedDirectusImage(backgroundImageUrl),
+            ),
           ),
-        ),
-        SliverLogo(
-          scaleFactor: scaleFactor,
-          activeGradient: activeGradient,
-          logoDirectusUrl: logoDirectusImageUrl,
-          logoOpacity: logoOpacity,
-          logoSize: logoSize,
-          boxfit: BoxFit.scaleDown,
-        ),
-      ],
+          SliverLogo(
+            scaleFactor: scaleFactor,
+            activeGradient: activeGradient,
+            logoDirectusUrl: logoDirectusImageUrl,
+            logoOpacity: logoOpacity,
+            logoSize: logoSize,
+            boxfit: BoxFit.scaleDown,
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/widgets/my_html_widget.dart
+++ b/lib/widgets/my_html_widget.dart
@@ -7,6 +7,8 @@ import "../theme/app_theme.dart";
 import "../utils/html_to_plain_text.dart";
 import "../utils/launch_url_util.dart";
 
+/// Widget that renders HTML. Supports semantics for screen readers and custom ToPWR styling.
+
 class MyHtmlWidget extends ConsumerWidget {
   const MyHtmlWidget(this.html, {super.key, this.textStyle});
   final String html;

--- a/lib/widgets/my_html_widget.dart
+++ b/lib/widgets/my_html_widget.dart
@@ -4,6 +4,7 @@ import "package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart
 
 import "../features/about_us_view/utils/html_util_extensions.dart";
 import "../theme/app_theme.dart";
+import "../utils/html_to_plain_text.dart";
 import "../utils/launch_url_util.dart";
 
 class MyHtmlWidget extends ConsumerWidget {
@@ -12,11 +13,16 @@ class MyHtmlWidget extends ConsumerWidget {
   final TextStyle? textStyle;
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return HtmlWidget(
-      html,
-      textStyle: textStyle ?? context.aboutUsTheme.body,
-      customStylesBuilder: context.customStylesBuilder,
-      onTapUrl: ref.launch,
+    return Semantics(
+      label: html.parseHtmlString(),
+      child: ExcludeSemantics(
+        child: HtmlWidget(
+          html,
+          textStyle: textStyle ?? context.aboutUsTheme.body,
+          customStylesBuilder: context.customStylesBuilder,
+          onTapUrl: ref.launch,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
- I've implemented support for screen readers
- I've implemented support for large fonts
- Color contrast and clickable area around items are well by default (imo)

#496 

![Screenshot_1746368296](https://github.com/user-attachments/assets/f866f25a-a5f8-4716-bd24-5effceaf03cd)
![Screenshot_1746368279](https://github.com/user-attachments/assets/5bf8800b-f219-4a8a-acc7-8f64011d6b2d)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance accessibility for the 'About Us' screen with screen reader support, semantic labels, and large font adjustments.
> 
>   - **Accessibility Enhancements**:
>     - Added semantic labels for screen readers in `custom_license_dialog.dart`, `app_version.dart`, `contact_section.dart`, `team_section.dart`, and `sliver_header_section.dart`.
>     - Implemented `HtmlToPlainTextX` extension in `html_to_plain_text.dart` for parsing HTML to plain text for screen readers.
>     - Updated `MyHtmlWidget` to include semantic labels for HTML content.
>   - **UI Adjustments**:
>     - Adjusted `AppVersionTile` and `_ContactIcon` to exclude semantics for non-essential elements.
>     - Modified `_TeamMemberCard` and `_Description` to use `Flexible` and `SingleChildScrollView` for better large font support.
>   - **Localization**:
>     - Added new localization strings `button_leading_to` and `logotype` in `app_en.arb` and `app_pl.arb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for fc0962a81bed92243b9415b79bea0fba1448a451. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->