### PR TITLE
feat(academic-calendar): implement upcoming day changes alert

### DIFF
--- a/lib/api_base/schema.graphql
+++ b/lib/api_base/schema.graphql
@@ -820,6 +820,7 @@ type AcademicCalendarData {
   isFirstWeekEven: Boolean!
   examSessionLastDay: Date!
   examSessionLastDay_func: date_functions
+  exceptionsLookupFutureWindowInDays: Int
 }
 
 type date_functions {
@@ -839,6 +840,7 @@ type version_AcademicCalendarData {
   examSessionStartDate: Date
   isFirstWeekEven: Boolean
   examSessionLastDay: Date
+  exceptionsLookupFutureWindowInDays: Int
 }
 
 type WeekExceptions {
@@ -2618,6 +2620,7 @@ input update_AcademicCalendarData_input {
   examSessionStartDate: Date
   isFirstWeekEven: Boolean
   examSessionLastDay: Date
+  exceptionsLookupFutureWindowInDays: Int
 }
 
 input update_WeekExceptions_input {

--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -46,7 +46,7 @@ abstract class DateChipConfig {
 abstract class HomeViewConfig {
   static const paddingSmall = 6.0;
   static const paddingMedium = 16.0;
-  static const bottomPadding = 24.0;
+  static const paddingLarge = 24.0;
 
   static const squareCardTextShadow = [
     Shadow(color: HexColor.consts(0x6621334D66), blurRadius: 4, offset: Offset(0, 2)),

--- a/lib/features/about_us_view/repository/about_us_repository.dart
+++ b/lib/features/about_us_view/repository/about_us_repository.dart
@@ -21,6 +21,10 @@ Future<AboutUsDetails?> aboutUsRepository(Ref ref) async {
   return AboutUsDetails(
     aboutUs: results.AboutUs?.copyWith(
       description: await ref.translateGraphQLMaybeString(results.AboutUs?.description),
+      solvroSocialLinks: await ref.translateGraphQLModelList(
+        results.AboutUs?.solvroSocialLinks ?? [],
+        (link) async => link?.copyWith(url: await ref.translateGraphQLMaybeString(link.url)),
+      ),
     ),
     versions: await ref.translateGraphQLModelIList(
       results.TeamVersions.lock,

--- a/lib/features/academic_calendar/model/academic_calendar_extensions.dart
+++ b/lib/features/academic_calendar/model/academic_calendar_extensions.dart
@@ -42,6 +42,8 @@ extension AcademicCalendarDataX on AcademicCalendarData {
 }
 
 extension AcademicCalendarX on AcademicCalendar {
+  Duration get windowDuration => Duration(days: data?.exceptionsLookupFutureWindowInDays ?? 7);
+
   AcademicDay? get academicDayToday {
     if (weeks.isTodayAnException && data != null) {
       return weeks.changedDayToday(data!) ?? data!.standardAcademicDay();
@@ -49,8 +51,8 @@ extension AcademicCalendarX on AcademicCalendar {
     return data?.standardAcademicDay();
   }
 
-  IncomingDaysChangesData? get incomingDaysChanges {
-    final nextException = weeks.nextExceptionsWithinWindow(const Duration(days: 30));
+  ({int daysTillFirstChange, int changesCount})? get incomingDaysChanges {
+    final nextException = weeks.nextExceptionsWithinWindow(windowDuration);
     final data = this.data;
     if (data == null || nextException.isEmpty) {
       return null;

--- a/lib/features/academic_calendar/model/academic_calendar_extensions.dart
+++ b/lib/features/academic_calendar/model/academic_calendar_extensions.dart
@@ -49,21 +49,12 @@ extension AcademicCalendarX on AcademicCalendar {
     return data?.standardAcademicDay();
   }
 
-  NextChangedDayData? get nextChangedDay {
-    final nextException = weeks.nextException;
+  IncomingDaysChangesData? get incomingDaysChanges {
+    final nextException = weeks.nextExceptionsWithinWindow(const Duration(days: 30));
     final data = this.data;
-    if (nextException == null || data == null) {
+    if (data == null || nextException.isEmpty) {
       return null;
     }
-    return (
-      dateTime: nextException.day,
-      standardAcademicDay: data.standardAcademicDay(nextException.day),
-      changedAcademicDay: AcademicDay(
-        isEven: nextException.changedDayIsEven,
-        isExamSession: data.isExamSession(nextException.day),
-        isHolidays: data.isHolidays(nextException.day),
-        weekday: WeekdayEnum.fromJson(nextException.changedWeekday),
-      ),
-    );
+    return (daysTillFirstChange: nextException.first.day.difference(now).inDays, changesCount: nextException.length);
   }
 }

--- a/lib/features/academic_calendar/model/academic_calendar_extensions.dart
+++ b/lib/features/academic_calendar/model/academic_calendar_extensions.dart
@@ -42,9 +42,9 @@ extension AcademicCalendarDataX on AcademicCalendarData {
 }
 
 extension AcademicCalendarX on AcademicCalendar {
-  AcademicDay? get academicDay {
-    if (weeks.isTodayAnException) {
-      return weeks.changedDayToday ?? data?.standardAcademicDay();
+  AcademicDay? get academicDayToday {
+    if (weeks.isTodayAnException && data != null) {
+      return weeks.changedDayToday(data!) ?? data!.standardAcademicDay();
     }
     return data?.standardAcademicDay();
   }

--- a/lib/features/academic_calendar/model/academic_calendar_extensions.dart
+++ b/lib/features/academic_calendar/model/academic_calendar_extensions.dart
@@ -45,14 +45,14 @@ extension AcademicCalendarX on AcademicCalendar {
   Duration get windowDuration => Duration(days: data?.exceptionsLookupFutureWindowInDays ?? 7);
 
   AcademicDay? get academicDayToday {
-    if (weeks.isTodayAnException && data != null) {
-      return weeks.changedDayToday(data!) ?? data!.standardAcademicDay();
+    if (swaps.isTodayAnException && data != null) {
+      return swaps.changedDayToday(data!) ?? data!.standardAcademicDay();
     }
     return data?.standardAcademicDay();
   }
 
   ({int daysTillFirstChange, int changesCount})? get incomingDaysChanges {
-    final nextException = weeks.nextExceptionsWithinWindow(windowDuration);
+    final nextException = swaps.nextDaySwapsWithinWindow(windowDuration);
     final data = this.data;
     if (data == null || nextException.isEmpty) {
       return null;

--- a/lib/features/academic_calendar/model/academic_calendar_extensions.dart
+++ b/lib/features/academic_calendar/model/academic_calendar_extensions.dart
@@ -5,33 +5,38 @@ import "academic_week_exception.dart";
 import "weekday_enum.dart";
 
 extension AcademicCalendarDataX on AcademicCalendarData {
-  bool isHolidays() {
-    return now.isBefore(semesterStartDate) || now.isAfter(examSessionLastDay);
+  bool isHolidays([DateTime? datetime]) {
+    final datetimeOrNow = datetime ?? now;
+    return datetimeOrNow.isBefore(semesterStartDate) || datetimeOrNow.isAfter(examSessionLastDay);
   }
 
-  bool isExamSession() {
-    return now.isAfterOrSameAs(examSessionStartDate) && now.isBeforeOrSameAs(examSessionLastDay);
+  bool isExamSession([DateTime? datetime]) {
+    final datetimeOrNow = datetime ?? now;
+    return datetimeOrNow.isAfterOrSameAs(examSessionStartDate) && datetimeOrNow.isBeforeOrSameAs(examSessionLastDay);
   }
 
-  bool isSemester() {
-    return now.isAfterOrSameAs(semesterStartDate) && now.isBefore(examSessionStartDate);
+  bool isSemester([DateTime? datetime]) {
+    final datetimeOrNow = datetime ?? now;
+    return datetimeOrNow.isAfterOrSameAs(semesterStartDate) && datetimeOrNow.isBefore(examSessionStartDate);
   }
 
-  bool shouldBeEvenWeek() {
+  bool shouldBeEvenWeek([DateTime? datetime]) {
+    final datetimeOrNow = datetime ?? now;
     final zeroMonday = semesterStartDate.findMondayOfTheWeek();
-    final numWeeksFromZeroMonday = zeroMonday.calculateWeeksTo(now);
+    final numWeeksFromZeroMonday = zeroMonday.calculateWeeksTo(datetimeOrNow);
     if (numWeeksFromZeroMonday.isEven) {
       return isFirstWeekEven;
     }
     return !isFirstWeekEven;
   }
 
-  AcademicDay get standardAcademicDay {
+  AcademicDay standardAcademicDay([DateTime? datetime]) {
+    final datetimeOrNow = datetime ?? now;
     return AcademicDay(
-      isEven: shouldBeEvenWeek(),
-      weekday: WeekdayEnum.fromDateTime(now),
-      isExamSession: isExamSession(),
-      isHolidays: isHolidays(),
+      isEven: shouldBeEvenWeek(datetimeOrNow),
+      weekday: WeekdayEnum.fromDateTime(datetimeOrNow),
+      isExamSession: isExamSession(datetimeOrNow),
+      isHolidays: isHolidays(datetimeOrNow),
     );
   }
 }
@@ -39,8 +44,26 @@ extension AcademicCalendarDataX on AcademicCalendarData {
 extension AcademicCalendarX on AcademicCalendar {
   AcademicDay? get academicDay {
     if (weeks.isTodayAnException) {
-      return weeks.changedDay ?? data?.standardAcademicDay;
+      return weeks.changedDayToday ?? data?.standardAcademicDay();
     }
-    return data?.standardAcademicDay;
+    return data?.standardAcademicDay();
+  }
+
+  NextChangedDayData? get nextChangedDay {
+    final nextException = weeks.nextException;
+    final data = this.data;
+    if (nextException == null || data == null) {
+      return null;
+    }
+    return (
+      dateTime: nextException.day,
+      standardAcademicDay: data.standardAcademicDay(nextException.day),
+      changedAcademicDay: AcademicDay(
+        isEven: nextException.changedDayIsEven,
+        isExamSession: data.isExamSession(nextException.day),
+        isHolidays: data.isHolidays(nextException.day),
+        weekday: WeekdayEnum.fromJson(nextException.changedWeekday),
+      ),
+    );
   }
 }

--- a/lib/features/academic_calendar/model/academic_week_exception.dart
+++ b/lib/features/academic_calendar/model/academic_week_exception.dart
@@ -13,7 +13,7 @@ extension AcademicWeekExceptionX on IList<AcademicWeekException> {
     return any(_checkIfThisIsToday);
   }
 
-  AcademicDay? get changedDay {
+  AcademicDay? get changedDayToday {
     final changedDayData = firstWhereOrNull(_checkIfThisIsToday);
     return changedDayData != null
         ? AcademicDay(
@@ -23,5 +23,11 @@ extension AcademicWeekExceptionX on IList<AcademicWeekException> {
           weekday: WeekdayEnum.fromJson(changedDayData.changedWeekday),
         )
         : null;
+  }
+
+  AcademicWeekException? get nextException {
+    final nextException =
+        where((element) => element.day.isAfter(now)).sorted((a, b) => a.day.compareTo(b.day)).firstOrNull;
+    return nextException;
   }
 }

--- a/lib/features/academic_calendar/model/academic_week_exception.dart
+++ b/lib/features/academic_calendar/model/academic_week_exception.dart
@@ -25,9 +25,11 @@ extension AcademicWeekExceptionX on IList<AcademicWeekException> {
         : null;
   }
 
-  AcademicWeekException? get nextException {
-    final nextException =
-        where((element) => element.day.isAfter(now)).sorted((a, b) => a.day.compareTo(b.day)).firstOrNull;
-    return nextException;
+  List<AcademicWeekException> nextExceptionsWithinWindow([Duration? windowDuration]) {
+    final duration = windowDuration ?? const Duration(days: 7);
+    final nowPlusWindow = now.add(duration);
+    return where(
+      (element) => element.day.isAfter(now) && element.day.isBefore(nowPlusWindow),
+    ).sorted((a, b) => a.day.compareTo(b.day));
   }
 }

--- a/lib/features/academic_calendar/model/academic_week_exception.dart
+++ b/lib/features/academic_calendar/model/academic_week_exception.dart
@@ -7,7 +7,7 @@ import "academic_calendar_extensions.dart";
 import "academic_day.dart";
 import "weekday_enum.dart";
 
-extension ExceptionX on AcademicWeekException {
+extension ExceptionDaySwapX on AcademicDaySwap {
   AcademicDay academicDay(AcademicCalendarData calendarData) {
     return AcademicDay(
       isEven: changedDayIsEven,
@@ -18,8 +18,8 @@ extension ExceptionX on AcademicWeekException {
   }
 }
 
-extension AcademicWeekExceptionX on IList<AcademicWeekException> {
-  bool _checkIfThisIsToday(AcademicWeekException element) => element.day.isSameDay(now);
+extension AcademicDaySwapListX on IList<AcademicDaySwap> {
+  bool _checkIfThisIsToday(AcademicDaySwap element) => element.day.isSameDay(now);
 
   bool get isTodayAnException {
     return any(_checkIfThisIsToday);
@@ -30,7 +30,7 @@ extension AcademicWeekExceptionX on IList<AcademicWeekException> {
     return changedDayData?.academicDay(calendarData);
   }
 
-  IList<AcademicWeekException> nextExceptionsWithinWindow([Duration? windowDuration]) {
+  IList<AcademicDaySwap> nextDaySwapsWithinWindow([Duration? windowDuration]) {
     final duration = windowDuration ?? const Duration(days: 7);
     final nowPlusWindow = now.add(duration);
     return where(

--- a/lib/features/academic_calendar/model/academic_week_exception.dart
+++ b/lib/features/academic_calendar/model/academic_week_exception.dart
@@ -3,8 +3,20 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 
 import "../../../utils/datetime_utils.dart";
 import "../repository/academic_calendar_repo.dart";
+import "academic_calendar_extensions.dart";
 import "academic_day.dart";
 import "weekday_enum.dart";
+
+extension ExceptionX on AcademicWeekException {
+  AcademicDay academicDay(AcademicCalendarData calendarData) {
+    return AcademicDay(
+      isEven: changedDayIsEven,
+      weekday: WeekdayEnum.fromJson(changedWeekday),
+      isExamSession: calendarData.isExamSession(day),
+      isHolidays: calendarData.isHolidays(day),
+    );
+  }
+}
 
 extension AcademicWeekExceptionX on IList<AcademicWeekException> {
   bool _checkIfThisIsToday(AcademicWeekException element) => element.day.isSameDay(now);
@@ -13,23 +25,16 @@ extension AcademicWeekExceptionX on IList<AcademicWeekException> {
     return any(_checkIfThisIsToday);
   }
 
-  AcademicDay? get changedDayToday {
+  AcademicDay? changedDayToday(AcademicCalendarData calendarData) {
     final changedDayData = firstWhereOrNull(_checkIfThisIsToday);
-    return changedDayData != null
-        ? AcademicDay(
-          isEven: changedDayData.changedDayIsEven,
-          isExamSession: false,
-          isHolidays: false,
-          weekday: WeekdayEnum.fromJson(changedDayData.changedWeekday),
-        )
-        : null;
+    return changedDayData?.academicDay(calendarData);
   }
 
-  List<AcademicWeekException> nextExceptionsWithinWindow([Duration? windowDuration]) {
+  IList<AcademicWeekException> nextExceptionsWithinWindow([Duration? windowDuration]) {
     final duration = windowDuration ?? const Duration(days: 7);
     final nowPlusWindow = now.add(duration);
     return where(
       (element) => element.day.isAfter(now) && element.day.isBefore(nowPlusWindow),
-    ).sorted((a, b) => a.day.compareTo(b.day));
+    ).toIList().sort((a, b) => a.day.compareTo(b.day));
   }
 }

--- a/lib/features/academic_calendar/model/next_changed_day.dart
+++ b/lib/features/academic_calendar/model/next_changed_day.dart
@@ -1,0 +1,3 @@
+import "academic_day.dart";
+
+typedef NextChangedDayData = ({DateTime dateTime, AcademicDay standardAcademicDay, AcademicDay changedAcademicDay});

--- a/lib/features/academic_calendar/model/next_changed_day.dart
+++ b/lib/features/academic_calendar/model/next_changed_day.dart
@@ -1,3 +1,5 @@
 import "academic_day.dart";
 
 typedef NextChangedDayData = ({DateTime dateTime, AcademicDay standardAcademicDay, AcademicDay changedAcademicDay});
+
+typedef IncomingDaysChangesData = ({int daysTillFirstChange, int changesCount});

--- a/lib/features/academic_calendar/model/next_changed_day.dart
+++ b/lib/features/academic_calendar/model/next_changed_day.dart
@@ -1,5 +1,0 @@
-import "academic_day.dart";
-
-typedef NextChangedDayData = ({DateTime dateTime, AcademicDay standardAcademicDay, AcademicDay changedAcademicDay});
-
-typedef IncomingDaysChangesData = ({int daysTillFirstChange, int changesCount});

--- a/lib/features/academic_calendar/repository/academic_calendar_repo.dart
+++ b/lib/features/academic_calendar/repository/academic_calendar_repo.dart
@@ -10,7 +10,7 @@ part "academic_calendar_repo.g.dart";
 
 typedef AcademicCalendar = Query$GetAcademicCalendar;
 typedef AcademicCalendarData = Query$GetAcademicCalendar$AcademicCalendarData;
-typedef AcademicWeekException = Query$GetAcademicCalendar$WeekExceptions;
+typedef AcademicDaySwap = Query$GetAcademicCalendar$WeekExceptions;
 
 @riverpod
 Future<AcademicCalendar?> academicCalendarRepo(Ref ref) {
@@ -19,5 +19,5 @@ Future<AcademicCalendar?> academicCalendarRepo(Ref ref) {
 
 extension FixNestedTypesX on AcademicCalendar {
   AcademicCalendarData? get data => this.AcademicCalendarData;
-  IList<AcademicWeekException> get weeks => WeekExceptions.lock;
+  IList<AcademicDaySwap> get swaps => WeekExceptions.lock;
 }

--- a/lib/features/academic_calendar/repository/getAcademicCalendar.graphql
+++ b/lib/features/academic_calendar/repository/getAcademicCalendar.graphql
@@ -4,6 +4,7 @@ query GetAcademicCalendar {
     examSessionLastDay
     semesterStartDate
     isFirstWeekEven
+    exceptionsLookupFutureWindowInDays
   }
   WeekExceptions {
     day

--- a/lib/features/academic_calendar/utils/localize_academic_day.dart
+++ b/lib/features/academic_calendar/utils/localize_academic_day.dart
@@ -5,10 +5,16 @@ import "../model/academic_day.dart";
 import "../model/weekday_enum.dart";
 
 extension LocalizeAcademicDayX on AcademicDay {
-  String localize(BuildContext context) {
+  String _localizeWithPrefix(BuildContext context) {
     if (isHolidays) return weekday.localizeHoliday(context);
     if (isExamSession) return weekday.localizeExamSession(context);
     return isEven ? weekday.localizeEven(context) : weekday.localizeOdd(context);
+  }
+
+  String localize(BuildContext context, {bool includePrefix = true}) {
+    final withPrefix = _localizeWithPrefix(context);
+    if (!includePrefix) return withPrefix.split(" ").skip(1).join(" ");
+    return withPrefix;
   }
 }
 

--- a/lib/features/academic_calendar/utils/localize_academic_day.dart
+++ b/lib/features/academic_calendar/utils/localize_academic_day.dart
@@ -11,7 +11,35 @@ extension LocalizeAcademicDayX on AcademicDay {
     return isEven ? weekday.localizeEven(context) : weekday.localizeOdd(context);
   }
 
-  String localize(BuildContext context, {bool includePrefix = true}) {
+  String _localizeDeclinedNoun(BuildContext context) {
+    // TODO(simon-the-shark): decline holiday and exam session days (but they shouldn't be used in this context anyway)
+    if (isHolidays) return weekday.localizeHoliday(context);
+    if (isExamSession) return weekday.localizeExamSession(context);
+    return isEven
+        ? switch (weekday) {
+          WeekdayEnum.mon => context.localize.even_monday_declined,
+          WeekdayEnum.tue => context.localize.even_tuesday_declined,
+          WeekdayEnum.wed => context.localize.even_wednesday_declined,
+          WeekdayEnum.thu => context.localize.even_thursday_declined,
+          WeekdayEnum.fri => context.localize.even_friday_declined,
+          WeekdayEnum.sat => context.localize.even_saturday_declined,
+          WeekdayEnum.sun => context.localize.even_sunday_declined,
+        }
+        : switch (weekday) {
+          WeekdayEnum.mon => context.localize.odd_monday_declined,
+          WeekdayEnum.tue => context.localize.odd_tuesday_declined,
+          WeekdayEnum.wed => context.localize.odd_wednesday_declined,
+          WeekdayEnum.thu => context.localize.odd_thursday_declined,
+          WeekdayEnum.fri => context.localize.odd_friday_declined,
+          WeekdayEnum.sat => context.localize.odd_saturday_declined,
+          WeekdayEnum.sun => context.localize.odd_sunday_declined,
+        };
+  }
+
+  String localize(BuildContext context, {bool includePrefix = true, bool getDeclinedNoun = false}) {
+    if (getDeclinedNoun) {
+      return _localizeDeclinedNoun(context);
+    }
     final withPrefix = _localizeWithPrefix(context);
     if (!includePrefix) return withPrefix.split(" ").skip(1).join(" ");
     return withPrefix;

--- a/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
+++ b/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
@@ -7,7 +7,7 @@ import "../../../widgets/my_error_widget.dart";
 import "../repository/academic_calendar_repo.dart";
 import "countdown_widget/exam_session_countdown.dart";
 import "home_screen_greeting.dart";
-import "next_changed_day.dart" show NextChangedDay;
+import "incoming_day_changes.dart" show IncomingDayChanges;
 
 class AcademicCalendarConsumer extends ConsumerWidget {
   const AcademicCalendarConsumer({super.key});
@@ -29,7 +29,7 @@ class AcademicCalendarConsumer extends ConsumerWidget {
           const SizedBox(height: HomeViewConfig.paddingMedium),
           ExamSessionCountdown(value),
           const SizedBox(height: HomeViewConfig.paddingMedium / 1.5),
-          const NextChangedDay(),
+          IncomingDayChanges(calendar: value),
         ],
       ),
       _ => const Padding(

--- a/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
+++ b/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
@@ -7,6 +7,7 @@ import "../../../widgets/my_error_widget.dart";
 import "../repository/academic_calendar_repo.dart";
 import "countdown_widget/exam_session_countdown.dart";
 import "home_screen_greeting.dart";
+import "next_changed_day.dart" show NextChangedDay;
 
 class AcademicCalendarConsumer extends ConsumerWidget {
   const AcademicCalendarConsumer({super.key});
@@ -23,7 +24,13 @@ class AcademicCalendarConsumer extends ConsumerWidget {
       AsyncValue(:final AcademicCalendar value) => Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [Greeting(value), const SizedBox(height: HomeViewConfig.paddingMedium), ExamSessionCountdown(value)],
+        children: [
+          Greeting(value),
+          const SizedBox(height: HomeViewConfig.paddingMedium),
+          ExamSessionCountdown(value),
+          const SizedBox(height: HomeViewConfig.paddingMedium),
+          NextChangedDay(academicCalendar: value),
+        ],
       ),
       _ => const Padding(
         padding: EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingMedium),

--- a/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
+++ b/lib/features/academic_calendar/widgets/academic_calendar_consumer.dart
@@ -28,8 +28,8 @@ class AcademicCalendarConsumer extends ConsumerWidget {
           Greeting(value),
           const SizedBox(height: HomeViewConfig.paddingMedium),
           ExamSessionCountdown(value),
-          const SizedBox(height: HomeViewConfig.paddingMedium),
-          NextChangedDay(academicCalendar: value),
+          const SizedBox(height: HomeViewConfig.paddingMedium / 1.5),
+          const NextChangedDay(),
         ],
       ),
       _ => const Padding(

--- a/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
+++ b/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../../../../config/ui_config.dart";
 import "../../../../config/url_config.dart";
 import "../../../../theme/app_theme.dart";
 import "../../../../utils/context_extensions.dart";
@@ -17,7 +18,7 @@ class ExamSessionCountdown extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingLarge),
       child: GestureDetector(
         onTap: () async => ref.launch(UrlConfig.academicCalendarUrl),
         child: Container(

--- a/lib/features/academic_calendar/widgets/day_changes_dialog.dart
+++ b/lib/features/academic_calendar/widgets/day_changes_dialog.dart
@@ -11,40 +11,36 @@ import "../repository/academic_calendar_repo.dart";
 import "../utils/localize_academic_day.dart";
 
 class DayChangesDialog extends ConsumerWidget {
-  const DayChangesDialog(this.calendar, {super.key, required this.windowDuration});
+  const DayChangesDialog(this.calendar, {super.key});
 
   final AcademicCalendar calendar;
-  final Duration windowDuration;
 
-  static Future<void> show(BuildContext context, AcademicCalendar calendar, Duration windowDuration) async {
-    return showDialog<void>(
-      context: context,
-      builder: (context) => DayChangesDialog(calendar, windowDuration: windowDuration),
-    );
+  static Future<void> show(BuildContext context, AcademicCalendar calendar) async {
+    return showDialog<void>(context: context, builder: (context) => DayChangesDialog(calendar));
   }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.localize;
-    final exceptions = calendar.weeks.nextExceptionsWithinWindow(windowDuration);
+    final weekExceptions = calendar.weeks.nextExceptionsWithinWindow(calendar.windowDuration);
     final calendarData = calendar.data;
     if (calendarData == null) {
       return const SizedBox.shrink();
     }
     return RedDialog(
       title: l10n.dayChangesDialogTitle,
-      subtitle: l10n.dayChangesDialogSubtitle(windowDuration.inDays),
+      subtitle: l10n.dayChangesDialogSubtitle(calendar.windowDuration.inDays),
       applyButtonText: l10n.dayChangesDialogOk,
       showCloseButton: false,
       child: ListView.separated(
         padding: const EdgeInsets.all(32),
         shrinkWrap: true,
-        itemCount: exceptions.length,
+        itemCount: weekExceptions.length,
         separatorBuilder: (context, index) => const Divider(height: 24),
         itemBuilder: (context, index) {
-          final change = exceptions[index];
-          final changedAcademicDay = change.academicDay(calendarData);
-          final standardAcademicDay = calendarData.standardAcademicDay(change.day);
+          final weekException = weekExceptions[index];
+          final changedAcademicDay = weekException.academicDay(calendarData);
+          final standardAcademicDay = calendarData.standardAcademicDay(weekException.day);
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -55,7 +51,7 @@ class DayChangesDialog extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      change.day.toDayDateString(context, includeWeekday: false, includeYear: false),
+                      weekException.day.toDayDateString(context, includeWeekday: false, includeYear: false),
                       style: context.textTheme.title.copyWith(fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 4),

--- a/lib/features/academic_calendar/widgets/day_changes_dialog.dart
+++ b/lib/features/academic_calendar/widgets/day_changes_dialog.dart
@@ -1,0 +1,87 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
+import "../../../utils/datetime_utils.dart";
+import "../../digital_guide/tabs/accessibility_dialog/presentation/red_dialog.dart";
+import "../model/academic_calendar_extensions.dart";
+import "../model/academic_week_exception.dart";
+import "../repository/academic_calendar_repo.dart";
+import "../utils/localize_academic_day.dart";
+
+class DayChangesDialog extends ConsumerWidget {
+  const DayChangesDialog(this.calendar, {super.key, required this.windowDuration});
+
+  final AcademicCalendar calendar;
+  final Duration windowDuration;
+
+  static Future<void> show(BuildContext context, AcademicCalendar calendar, Duration windowDuration) async {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => DayChangesDialog(calendar, windowDuration: windowDuration),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.localize;
+    final exceptions = calendar.weeks.nextExceptionsWithinWindow(windowDuration);
+    final calendarData = calendar.data;
+    if (calendarData == null) {
+      return const SizedBox.shrink();
+    }
+    return RedDialog(
+      title: l10n.dayChangesDialogTitle,
+      subtitle: l10n.dayChangesDialogSubtitle(windowDuration.inDays),
+      applyButtonText: l10n.dayChangesDialogOk,
+      showCloseButton: false,
+      child: ListView.separated(
+        padding: const EdgeInsets.all(32),
+        shrinkWrap: true,
+        itemCount: exceptions.length,
+        separatorBuilder: (context, index) => const Divider(height: 24),
+        itemBuilder: (context, index) {
+          final change = exceptions[index];
+          final changedAcademicDay = change.academicDay(calendarData);
+          final standardAcademicDay = calendarData.standardAcademicDay(change.day);
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.swap_horiz, color: context.colorTheme.orangePomegranade, size: 32),
+              const SizedBox(width: 16),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      change.day.toDayDateString(context, includeWeekday: false, includeYear: false),
+                      style: context.textTheme.title.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 4),
+                    Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(text: "${l10n.day_changes_dialog_will_be} "),
+                          TextSpan(
+                            text: changedAcademicDay.localize(context, includePrefix: false),
+                            style: const TextStyle(fontWeight: FontWeight.bold),
+                          ),
+                          TextSpan(
+                            text:
+                                " (${l10n.day_changes_dialog_instead_of} ${standardAcademicDay.localize(context, includePrefix: false)})",
+                          ),
+                        ],
+                      ),
+                      style: context.textTheme.body,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/academic_calendar/widgets/day_changes_dialog.dart
+++ b/lib/features/academic_calendar/widgets/day_changes_dialog.dart
@@ -22,7 +22,7 @@ class DayChangesDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.localize;
-    final weekExceptions = calendar.weeks.nextExceptionsWithinWindow(calendar.windowDuration);
+    final swaps = calendar.swaps.nextDaySwapsWithinWindow(calendar.windowDuration);
     final calendarData = calendar.data;
     if (calendarData == null) {
       return const SizedBox.shrink();
@@ -35,12 +35,12 @@ class DayChangesDialog extends ConsumerWidget {
       child: ListView.separated(
         padding: const EdgeInsets.all(32),
         shrinkWrap: true,
-        itemCount: weekExceptions.length,
+        itemCount: swaps.length,
         separatorBuilder: (context, index) => const Divider(height: 24),
         itemBuilder: (context, index) {
-          final weekException = weekExceptions[index];
-          final changedAcademicDay = weekException.academicDay(calendarData);
-          final standardAcademicDay = calendarData.standardAcademicDay(weekException.day);
+          final swap = swaps[index];
+          final swappedAcademicDay = swap.academicDay(calendarData);
+          final standardAcademicDay = calendarData.standardAcademicDay(swap.day);
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -51,7 +51,7 @@ class DayChangesDialog extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      weekException.day.toDayDateString(context, includeWeekday: false, includeYear: false),
+                      swap.day.toDayDateString(context, includeWeekday: false, includeYear: false),
                       style: context.textTheme.title.copyWith(fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 4),
@@ -60,7 +60,7 @@ class DayChangesDialog extends ConsumerWidget {
                         children: [
                           TextSpan(text: "${l10n.day_changes_dialog_will_be} "),
                           TextSpan(
-                            text: changedAcademicDay.localize(context, includePrefix: false),
+                            text: swappedAcademicDay.localize(context, includePrefix: false),
                             style: const TextStyle(fontWeight: FontWeight.bold),
                           ),
                           TextSpan(

--- a/lib/features/academic_calendar/widgets/day_changes_dialog.dart
+++ b/lib/features/academic_calendar/widgets/day_changes_dialog.dart
@@ -65,7 +65,7 @@ class DayChangesDialog extends ConsumerWidget {
                           ),
                           TextSpan(
                             text:
-                                " (${l10n.day_changes_dialog_instead_of} ${standardAcademicDay.localize(context, includePrefix: false)})",
+                                " (${l10n.day_changes_dialog_instead_of} ${standardAcademicDay.localize(context, includePrefix: false, getDeclinedNoun: true)})",
                           ),
                         ],
                       ),

--- a/lib/features/academic_calendar/widgets/day_changes_dialog.dart
+++ b/lib/features/academic_calendar/widgets/day_changes_dialog.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../../../config/ui_config.dart";
 import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../utils/datetime_utils.dart";
@@ -36,7 +37,7 @@ class DayChangesDialog extends ConsumerWidget {
         padding: const EdgeInsets.all(32),
         shrinkWrap: true,
         itemCount: swaps.length,
-        separatorBuilder: (context, index) => const Divider(height: 24),
+        separatorBuilder: (context, index) => const Divider(height: HomeViewConfig.paddingLarge),
         itemBuilder: (context, index) {
           final swap = swaps[index];
           final swappedAcademicDay = swap.academicDay(calendarData);

--- a/lib/features/academic_calendar/widgets/home_screen_greeting.dart
+++ b/lib/features/academic_calendar/widgets/home_screen_greeting.dart
@@ -18,7 +18,7 @@ class Greeting extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(context.localize.home_screen_greeting, style: context.greetingTheme.textStyle),
-          Text(academicCalendar.academicDay?.localize(context) ?? "", style: context.greetingTheme.boldTextStyle),
+          Text(academicCalendar.academicDayToday?.localize(context) ?? "", style: context.greetingTheme.boldTextStyle),
         ],
       ),
     );

--- a/lib/features/academic_calendar/widgets/home_screen_greeting.dart
+++ b/lib/features/academic_calendar/widgets/home_screen_greeting.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 
+import "../../../config/ui_config.dart";
 import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../model/academic_calendar_extensions.dart";
@@ -12,7 +13,7 @@ class Greeting extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingLarge),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/features/academic_calendar/widgets/incoming_day_changes.dart
+++ b/lib/features/academic_calendar/widgets/incoming_day_changes.dart
@@ -21,7 +21,7 @@ class IncomingDayChanges extends StatelessWidget {
       child: MySplashTile(
         backgroundColor: Colors.transparent,
         onTap: () async {
-          await DayChangesDialog.show(context, calendar, const Duration(days: 30));
+          await DayChangesDialog.show(context, calendar);
         },
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/features/academic_calendar/widgets/incoming_day_changes.dart
+++ b/lib/features/academic_calendar/widgets/incoming_day_changes.dart
@@ -4,6 +4,7 @@ import "../../../utils/context_extensions.dart";
 import "../../../widgets/my_splash_tile.dart";
 import "../model/academic_calendar_extensions.dart";
 import "../repository/academic_calendar_repo.dart";
+import "day_changes_dialog.dart";
 
 class IncomingDayChanges extends StatelessWidget {
   const IncomingDayChanges({super.key, required this.calendar});
@@ -19,7 +20,9 @@ class IncomingDayChanges extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: MySplashTile(
         backgroundColor: Colors.transparent,
-        onTap: () {},
+        onTap: () async {
+          await DayChangesDialog.show(context, calendar, const Duration(days: 30));
+        },
         child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
           child: Row(

--- a/lib/features/academic_calendar/widgets/incoming_day_changes.dart
+++ b/lib/features/academic_calendar/widgets/incoming_day_changes.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "../../../widgets/my_splash_tile.dart";
 import "../model/academic_calendar_extensions.dart";
 import "../repository/academic_calendar_repo.dart";
@@ -13,6 +14,7 @@ class IncomingDayChanges extends StatelessWidget {
     if (data == null) {
       return const SizedBox.shrink();
     }
+    final l10n = context.localize;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: MySplashTile(
@@ -46,7 +48,7 @@ class IncomingDayChanges extends StatelessWidget {
                     Icon(Icons.warning_amber, size: 18, color: context.colorTheme.whiteSoap),
                     const SizedBox(width: 6),
                     Text(
-                      "${data.daysTillFirstChange} dni",
+                      l10n.incoming_days_changes_days(data.daysTillFirstChange),
                       style: context.textTheme.bodyWhite.copyWith(fontWeight: FontWeight.bold, fontSize: 16),
                     ),
                   ],
@@ -54,7 +56,7 @@ class IncomingDayChanges extends StatelessWidget {
               ),
               const SizedBox(width: 12),
               Text(
-                "Nadchodzące ${data.changesCount} zmiany dnia!",
+                l10n.incoming_days_changes_title(data.changesCount),
                 style: context.textTheme.body.copyWith(fontWeight: FontWeight.w500, fontSize: 15),
               ),
               const SizedBox(width: 6),

--- a/lib/features/academic_calendar/widgets/incoming_day_changes.dart
+++ b/lib/features/academic_calendar/widgets/incoming_day_changes.dart
@@ -1,12 +1,18 @@
 import "package:flutter/material.dart";
 import "../../../theme/app_theme.dart";
 import "../../../widgets/my_splash_tile.dart";
+import "../model/academic_calendar_extensions.dart";
+import "../repository/academic_calendar_repo.dart";
 
-class NextChangedDay extends StatelessWidget {
-  const NextChangedDay({super.key});
-
+class IncomingDayChanges extends StatelessWidget {
+  const IncomingDayChanges({super.key, required this.calendar});
+  final AcademicCalendar calendar;
   @override
   Widget build(BuildContext context) {
+    final data = calendar.incomingDaysChanges;
+    if (data == null) {
+      return const SizedBox.shrink();
+    }
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: MySplashTile(
@@ -40,7 +46,7 @@ class NextChangedDay extends StatelessWidget {
                     Icon(Icons.warning_amber, size: 18, color: context.colorTheme.whiteSoap),
                     const SizedBox(width: 6),
                     Text(
-                      "17 dni",
+                      "${data.daysTillFirstChange} dni",
                       style: context.textTheme.bodyWhite.copyWith(fontWeight: FontWeight.bold, fontSize: 16),
                     ),
                   ],
@@ -48,7 +54,7 @@ class NextChangedDay extends StatelessWidget {
               ),
               const SizedBox(width: 12),
               Text(
-                "Nadchodzące 3 zmiany dnia!",
+                "Nadchodzące ${data.changesCount} zmiany dnia!",
                 style: context.textTheme.body.copyWith(fontWeight: FontWeight.w500, fontSize: 15),
               ),
               const SizedBox(width: 6),

--- a/lib/features/academic_calendar/widgets/incoming_day_changes.dart
+++ b/lib/features/academic_calendar/widgets/incoming_day_changes.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "../../../config/ui_config.dart";
 import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/my_splash_tile.dart";
@@ -17,7 +18,7 @@ class IncomingDayChanges extends StatelessWidget {
     }
     final l10n = context.localize;
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingLarge),
       child: MySplashTile(
         backgroundColor: Colors.transparent,
         onTap: () async {

--- a/lib/features/academic_calendar/widgets/next_changed_day.dart
+++ b/lib/features/academic_calendar/widgets/next_changed_day.dart
@@ -1,48 +1,60 @@
 import "package:flutter/material.dart";
-import "../../../l10n/app_localizations.dart";
 import "../../../theme/app_theme.dart";
-import "../../../utils/context_extensions.dart";
-import "../../../utils/datetime_utils.dart";
-import "../model/academic_calendar_extensions.dart";
-import "../repository/academic_calendar_repo.dart";
-import "../utils/localize_academic_day.dart";
+import "../../../widgets/my_splash_tile.dart";
 
 class NextChangedDay extends StatelessWidget {
-  const NextChangedDay({super.key, required this.academicCalendar});
-
-  final AcademicCalendar academicCalendar;
+  const NextChangedDay({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final nextChangedDay = academicCalendar.nextChangedDay;
-    if (nextChangedDay == null) {
-      return const SizedBox.shrink();
-    }
-    final boldStyle = context.greetingTheme.boldTextStyle.copyWith(fontSize: 16);
-    return Padding(
+    return Container(
       padding: const EdgeInsets.symmetric(horizontal: 24),
-      child: RichText(
-        textAlign: TextAlign.justify,
-        text: TextSpan(
-          style: context.greetingTheme.textStyle.copyWith(fontSize: 16),
-          children: [
-            TextSpan(text: AppLocalizations.of(context)!.next_changed_day_prefix),
-            TextSpan(text: nextChangedDay.dateTime.daysLeftFromNow.toString(), style: boldStyle),
-            TextSpan(
-              text:
-                  context.localize.next_changed_day_days +
-                  nextChangedDay.dateTime.toDayDateString(context, includeWeekday: false, includeYear: false) +
-                  context.localize.next_changed_day_date_suffix,
-              style: boldStyle,
-            ),
-            TextSpan(text: context.localize.next_changed_day_from),
-            TextSpan(
-              text: nextChangedDay.standardAcademicDay.localize(context, includePrefix: false),
-              style: boldStyle,
-            ),
-            TextSpan(text: context.localize.next_changed_day_to),
-            TextSpan(text: nextChangedDay.changedAcademicDay.localize(context, includePrefix: false), style: boldStyle),
-          ],
+      child: MySplashTile(
+        backgroundColor: Colors.transparent,
+        onTap: () {},
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [context.colorTheme.orangePomegranadeLighter, context.colorTheme.orangePomegranade],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: [
+                    BoxShadow(
+                      color: context.colorTheme.orangePomegranade.withValues(alpha: 0.15),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.warning_amber, size: 18, color: context.colorTheme.whiteSoap),
+                    const SizedBox(width: 6),
+                    Text(
+                      "17 dni",
+                      style: context.textTheme.bodyWhite.copyWith(fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                "Nadchodzące 3 zmiany dnia!",
+                style: context.textTheme.body.copyWith(fontWeight: FontWeight.w500, fontSize: 15),
+              ),
+              const SizedBox(width: 6),
+              Icon(Icons.info_outline, size: 18, color: context.colorTheme.greyPigeon),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/academic_calendar/widgets/next_changed_day.dart
+++ b/lib/features/academic_calendar/widgets/next_changed_day.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
-
+import "../../../l10n/app_localizations.dart";
 import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "../../../utils/datetime_utils.dart";
 import "../model/academic_calendar_extensions.dart";
 import "../repository/academic_calendar_repo.dart";
@@ -25,20 +26,21 @@ class NextChangedDay extends StatelessWidget {
         text: TextSpan(
           style: context.greetingTheme.textStyle.copyWith(fontSize: 16),
           children: [
-            const TextSpan(text: "Następna zamiana dnia już za "),
+            TextSpan(text: AppLocalizations.of(context)!.next_changed_day_prefix),
             TextSpan(text: nextChangedDay.dateTime.daysLeftFromNow.toString(), style: boldStyle),
             TextSpan(
               text:
-                  " dni (${nextChangedDay.dateTime.toDayDateString(context, includeWeekday: false, includeYear: false)}) ",
+                  context.localize.next_changed_day_days +
+                  nextChangedDay.dateTime.toDayDateString(context, includeWeekday: false, includeYear: false) +
+                  context.localize.next_changed_day_date_suffix,
               style: boldStyle,
             ),
-
-            const TextSpan(text: " z "),
+            TextSpan(text: context.localize.next_changed_day_from),
             TextSpan(
               text: nextChangedDay.standardAcademicDay.localize(context, includePrefix: false),
               style: boldStyle,
             ),
-            const TextSpan(text: " na "),
+            TextSpan(text: context.localize.next_changed_day_to),
             TextSpan(text: nextChangedDay.changedAcademicDay.localize(context, includePrefix: false), style: boldStyle),
           ],
         ),

--- a/lib/features/academic_calendar/widgets/next_changed_day.dart
+++ b/lib/features/academic_calendar/widgets/next_changed_day.dart
@@ -1,0 +1,48 @@
+import "package:flutter/material.dart";
+
+import "../../../theme/app_theme.dart";
+import "../../../utils/datetime_utils.dart";
+import "../model/academic_calendar_extensions.dart";
+import "../repository/academic_calendar_repo.dart";
+import "../utils/localize_academic_day.dart";
+
+class NextChangedDay extends StatelessWidget {
+  const NextChangedDay({super.key, required this.academicCalendar});
+
+  final AcademicCalendar academicCalendar;
+
+  @override
+  Widget build(BuildContext context) {
+    final nextChangedDay = academicCalendar.nextChangedDay;
+    if (nextChangedDay == null) {
+      return const SizedBox.shrink();
+    }
+    final boldStyle = context.greetingTheme.boldTextStyle.copyWith(fontSize: 16);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: RichText(
+        textAlign: TextAlign.justify,
+        text: TextSpan(
+          style: context.greetingTheme.textStyle.copyWith(fontSize: 16),
+          children: [
+            const TextSpan(text: "Następna zamiana dnia już za "),
+            TextSpan(text: nextChangedDay.dateTime.daysLeftFromNow.toString(), style: boldStyle),
+            TextSpan(
+              text:
+                  " dni (${nextChangedDay.dateTime.toDayDateString(context, includeWeekday: false, includeYear: false)}) ",
+              style: boldStyle,
+            ),
+
+            const TextSpan(text: " z "),
+            TextSpan(
+              text: nextChangedDay.standardAcademicDay.localize(context, includePrefix: false),
+              style: boldStyle,
+            ),
+            const TextSpan(text: " na "),
+            TextSpan(text: nextChangedDay.changedAcademicDay.localize(context, includePrefix: false), style: boldStyle),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/departments/department_detail_view/repository/department_details_repository.dart
+++ b/lib/features/departments/department_detail_view/repository/department_details_repository.dart
@@ -23,7 +23,10 @@ Future<DepartmentDetails?> departmentDetailsRepository(Ref ref, String id) async
       name: await ref.translateGraphQLMaybeString(detail.Departments_by_id?.name),
       links: await ref.translateGraphQLModelList(
         detail.Departments_by_id?.links ?? [],
-        (link) async => link?.copyWith(name: await ref.translateGraphQLMaybeString(link.name)),
+        (link) async => link?.copyWith(
+          name: await ref.translateGraphQLMaybeString(link.name),
+          link: await ref.translateGraphQLMaybeString(link.link),
+        ),
       ),
     ),
   );

--- a/lib/features/digital_guide/tabs/accessibility_dialog/presentation/red_dialog.dart
+++ b/lib/features/digital_guide/tabs/accessibility_dialog/presentation/red_dialog.dart
@@ -12,6 +12,7 @@ class RedDialog extends StatelessWidget {
   final bool showApplyButton;
   final bool centerTitle;
   final String? applyButtonText;
+  final bool showCloseButton;
   const RedDialog({
     super.key,
     required this.title,
@@ -20,6 +21,7 @@ class RedDialog extends StatelessWidget {
     this.showApplyButton = true,
     this.centerTitle = false,
     this.applyButtonText,
+    this.showCloseButton = true,
   });
   @override
   Widget build(BuildContext context) {
@@ -40,7 +42,7 @@ class RedDialog extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _DialogHeader(title: title, centerTitle: centerTitle),
+              _DialogHeader(title: title, centerTitle: centerTitle, showCloseButton: showCloseButton),
               Flexible(
                 child: SingleChildScrollView(
                   child: _DialogContent(
@@ -118,10 +120,11 @@ class _DialogFooter extends StatelessWidget {
 }
 
 class _DialogHeader extends StatelessWidget {
-  const _DialogHeader({required this.title, required this.centerTitle});
+  const _DialogHeader({required this.title, required this.centerTitle, required this.showCloseButton});
 
   final String title;
   final bool centerTitle;
+  final bool showCloseButton;
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -137,10 +140,17 @@ class _DialogHeader extends StatelessWidget {
             ),
           ),
           if (!centerTitle)
-            IconButton(
-              icon: const Icon(Icons.close),
-              color: context.colorTheme.greyPigeon,
-              onPressed: () => Navigator.of(context).pop(),
+            // a workaround, but the actual button provides some padding too and I don't have a power to play around with paddings anymore
+            Opacity(
+              opacity: showCloseButton ? 1 : 0,
+              child: IgnorePointer(
+                ignoring: !showCloseButton,
+                child: IconButton(
+                  icon: const Icon(Icons.close),
+                  color: context.colorTheme.greyPigeon,
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ),
             ),
         ],
       ),

--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -5,6 +5,8 @@ import "package:flutter/material.dart";
 import "../../config/ui_config.dart";
 import "../../theme/app_theme.dart";
 import "../academic_calendar/widgets/academic_calendar_consumer.dart";
+import "../planner_advert/widgets/banner_visibility.dart";
+import "../planner_advert/widgets/planer_ad_badge.dart";
 import "../planner_advert/widgets/planner_advert_widget.dart";
 import "keep_alive_home_view_providers.dart";
 import "widgets/buildings_section/buildings_section.dart";
@@ -22,7 +24,7 @@ class HomeView extends StatelessWidget {
         [
           const AcademicCalendarConsumer(),
           const NavActionsSection(),
-          const PlannerAdvertBanner(),
+          const PlannerBannerVisibility(child: PlannerAdvertBanner()),
           const ScienceClubsSection(),
           const BuildingsSection(),
         ].lock;
@@ -30,7 +32,7 @@ class HomeView extends StatelessWidget {
     return Scaffold(
       primary: false,
       backgroundColor: context.colorTheme.whiteSoap,
-      appBar: LogoAppBar(context),
+      appBar: LogoAppBar(context, actions: const [PlannerBannerVisibility(reverseLogic: true, child: PlanerAdBadge())]),
       body: KeepAliveHomeViewProviders(
         child: ListView.separated(
           itemBuilder: (context, index) => sections[index],

--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -5,7 +5,6 @@ import "package:flutter/material.dart";
 import "../../config/ui_config.dart";
 import "../../theme/app_theme.dart";
 import "../academic_calendar/widgets/academic_calendar_consumer.dart";
-import "../planner_advert/widgets/planner_advert_widget.dart";
 import "keep_alive_home_view_providers.dart";
 import "widgets/buildings_section/buildings_section.dart";
 import "widgets/logo_app_bar.dart";
@@ -21,8 +20,8 @@ class HomeView extends StatelessWidget {
     final sections =
         [
           const AcademicCalendarConsumer(),
-          const Padding(padding: EdgeInsets.only(top: 12, bottom: 4), child: NavActionsSection()),
-          PlannerAdvertBanner(),
+          const NavActionsSection(),
+          // const PlannerAdvertBanner(),
           const ScienceClubsSection(),
           const BuildingsSection(),
         ].lock;

--- a/lib/features/home_view/home_view.dart
+++ b/lib/features/home_view/home_view.dart
@@ -5,6 +5,7 @@ import "package:flutter/material.dart";
 import "../../config/ui_config.dart";
 import "../../theme/app_theme.dart";
 import "../academic_calendar/widgets/academic_calendar_consumer.dart";
+import "../planner_advert/widgets/planner_advert_widget.dart";
 import "keep_alive_home_view_providers.dart";
 import "widgets/buildings_section/buildings_section.dart";
 import "widgets/logo_app_bar.dart";
@@ -21,7 +22,7 @@ class HomeView extends StatelessWidget {
         [
           const AcademicCalendarConsumer(),
           const NavActionsSection(),
-          // const PlannerAdvertBanner(),
+          const PlannerAdvertBanner(),
           const ScienceClubsSection(),
           const BuildingsSection(),
         ].lock;

--- a/lib/features/planner_advert/repository/planner_advert_repository.dart
+++ b/lib/features/planner_advert/repository/planner_advert_repository.dart
@@ -2,6 +2,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../api_base/query_adapter.dart";
+import "../../../api_base/translations/temp_graphql_translate.dart";
 import "../../../config/ttl_config.dart";
 import "getPlannerAdvertContent.graphql.dart";
 
@@ -13,5 +14,9 @@ typedef PlannerAdvertContent = Query$GetPlannerAdvertContent$PlannerAdvert;
 Future<PlannerAdvertContent?> plannerAdvertContentRepository(Ref ref) async {
   final results = await ref.queryGraphql(Options$Query$GetPlannerAdvertContent(), TtlKey.plannerAdvertRepository);
 
-  return results?.PlannerAdvert;
+  return results?.PlannerAdvert?.copyWith(
+    title: await ref.translateGraphQLMaybeString(results.PlannerAdvert?.title),
+    description: await ref.translateGraphQLMaybeString(results.PlannerAdvert?.description),
+    url: await ref.translateGraphQLMaybeString(results.PlannerAdvert?.url),
+  );
 }

--- a/lib/features/planner_advert/widgets/banner_visibility.dart
+++ b/lib/features/planner_advert/widgets/banner_visibility.dart
@@ -25,7 +25,7 @@ class PlannerBannerVisibility extends ConsumerWidget {
     final academicCalendar = ref.watch(academicCalendarRepoProvider);
     return switch (academicCalendar) {
       AsyncData(:final AcademicCalendar? value) =>
-        value == null || value.weeks.nextExceptionsWithinWindow(value.windowDuration).isEmpty
+        value == null || value.swaps.nextDaySwapsWithinWindow(value.windowDuration).isEmpty
             ? (reverseLogic ? const SizedBox.shrink() : child)
             : (reverseLogic ? child : const SizedBox.shrink()),
       _ => const SizedBox.shrink(),

--- a/lib/features/planner_advert/widgets/banner_visibility.dart
+++ b/lib/features/planner_advert/widgets/banner_visibility.dart
@@ -1,0 +1,34 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../academic_calendar/model/academic_calendar_extensions.dart";
+import "../../academic_calendar/model/academic_week_exception.dart";
+import "../../academic_calendar/repository/academic_calendar_repo.dart";
+
+/// A widget that controls visibility of a child widget based on academic calendar data.
+///
+/// Shows the child widget only when there is no academic calendar data available.
+/// Otherwise, renders an empty [SizedBox].
+///
+/// This is used to show/hide the planner advertisement banner depending on whether
+/// academic calendar information exists.
+class PlannerBannerVisibility extends ConsumerWidget {
+  const PlannerBannerVisibility({super.key, required this.child, this.reverseLogic = false});
+  final Widget child;
+
+  /// When [reverseLogic] is false (default), the [child] is shown only if there is no academic calendar data.
+  /// When [reverseLogic] is true, the [child] is shown only if there is academic calendar data.
+  final bool reverseLogic;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final academicCalendar = ref.watch(academicCalendarRepoProvider);
+    return switch (academicCalendar) {
+      AsyncData(:final AcademicCalendar? value) =>
+        value == null || value.weeks.nextExceptionsWithinWindow(value.windowDuration).isEmpty
+            ? (reverseLogic ? const SizedBox.shrink() : child)
+            : (reverseLogic ? child : const SizedBox.shrink()),
+      _ => const SizedBox.shrink(),
+    };
+  }
+}

--- a/lib/features/planner_advert/widgets/planer_ad_badge.dart
+++ b/lib/features/planner_advert/widgets/planer_ad_badge.dart
@@ -1,0 +1,62 @@
+import "dart:async";
+
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../../theme/app_theme.dart";
+import "../../../theme/hex_color.dart";
+import "../../../utils/launch_url_util.dart";
+import "../../../widgets/my_alert_dialog.dart";
+import "../../../widgets/my_error_widget.dart";
+import "../repository/planner_advert_repository.dart";
+import "planer_badge_dialog.dart";
+
+class PlanerAdBadge extends ConsumerWidget {
+  const PlanerAdBadge({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(plannerAdvertContentRepositoryProvider);
+    return switch (state) {
+      AsyncError(:final error) => MyErrorWidget(error),
+      AsyncValue(:final PlannerAdvertContent value) => _BadgeContent(value),
+      _ => const SizedBox.shrink(),
+    };
+  }
+}
+
+class _BadgeContent extends ConsumerWidget {
+  const _BadgeContent(this.data);
+
+  final PlannerAdvertContent data;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!data.isEnabled) return const SizedBox.shrink();
+    final textColor = data.textColor != null ? HexColor(data.textColor!) : context.colorTheme.blackMirage;
+    final backgroundColor = data.backgroundColor != null ? HexColor(data.backgroundColor!) : null;
+    return Padding(
+      padding: const EdgeInsets.only(right: 12),
+      child: OutlinedButton(
+        onPressed: () async {
+          await showCustomDialog(
+            context: context,
+            onConfirmTapped: (context) {
+              unawaited(ref.launch(data.url!));
+              Navigator.pop(context);
+            },
+            confirmText: "Czytaj więcej",
+            dialogContent: PlanerBadgeDialogContent(data: data),
+          );
+        },
+        style: OutlinedButton.styleFrom(
+          shape: const CircleBorder(),
+          side: const BorderSide(color: Colors.transparent),
+          backgroundColor: backgroundColor,
+          padding: const EdgeInsets.all(8),
+          elevation: 2,
+        ),
+        child: Icon(Icons.warning_rounded, color: textColor, size: 24),
+      ),
+    );
+  }
+}

--- a/lib/features/planner_advert/widgets/planer_ad_badge.dart
+++ b/lib/features/planner_advert/widgets/planer_ad_badge.dart
@@ -5,6 +5,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../theme/app_theme.dart";
 import "../../../theme/hex_color.dart";
+import "../../../utils/context_extensions.dart";
 import "../../../utils/launch_url_util.dart";
 import "../../../widgets/my_alert_dialog.dart";
 import "../../../widgets/my_error_widget.dart";
@@ -44,7 +45,7 @@ class _BadgeContent extends ConsumerWidget {
               unawaited(ref.launch(data.url!));
               Navigator.pop(context);
             },
-            confirmText: "Czytaj więcej",
+            confirmText: context.localize.read_more,
             dialogContent: PlanerBadgeDialogContent(data: data),
           );
         },

--- a/lib/features/planner_advert/widgets/planer_badge_dialog.dart
+++ b/lib/features/planner_advert/widgets/planer_badge_dialog.dart
@@ -1,0 +1,20 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "../../../theme/app_theme.dart";
+import "../repository/planner_advert_repository.dart";
+
+class PlanerBadgeDialogContent extends ConsumerWidget {
+  const PlanerBadgeDialogContent({super.key, required this.data});
+  final PlannerAdvertContent data;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(data.title ?? "", style: context.textTheme.headline),
+        const SizedBox(height: 12),
+        Text(data.description, style: context.textTheme.lightTitle),
+      ],
+    );
+  }
+}

--- a/lib/features/planner_advert/widgets/planner_advert_widget.dart
+++ b/lib/features/planner_advert/widgets/planner_advert_widget.dart
@@ -13,6 +13,8 @@ import "../../../widgets/technical_message.dart";
 import "../repository/planner_advert_repository.dart";
 
 class PlannerAdvertBanner extends ConsumerWidget {
+  const PlannerAdvertBanner({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(plannerAdvertContentRepositoryProvider);
@@ -42,6 +44,7 @@ class _PlannerAdvertBanner extends ConsumerWidget {
         : Padding(
           padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingSmall),
           child: TechnicalMessage(
+            padding: const EdgeInsets.all(HomeViewConfig.paddingMedium).copyWith(bottom: 0),
             title: data.title,
             titleColor: data.titleColor != null ? HexColor(data.titleColor!) : null,
             message: data.description,

--- a/lib/features/science_club/science_club_detail_view/repository/science_club_details_repository.dart
+++ b/lib/features/science_club/science_club_detail_view/repository/science_club_details_repository.dart
@@ -25,7 +25,10 @@ Future<ScienceClubDetails?> scienceClubDetailsRepository(Ref ref, String id) asy
     description: await ref.translateGraphQLMaybeString(club.description),
     links: await ref.translateGraphQLModelList(
       club.links ?? [],
-      (link) async => link?.copyWith(name: await ref.translateGraphQLMaybeString(link.name)),
+      (link) async => link?.copyWith(
+        name: await ref.translateGraphQLMaybeString(link.name),
+        link: await ref.translateGraphQLMaybeString(link.link),
+      ),
     ),
   );
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -493,10 +493,10 @@
   "button_leading_to": "Button leading to",
   "logotype": "Logotype",
   "incoming_days_changes_days": "{days, plural, =1{1 day} other{{days} days}}",
-  "incoming_days_changes_title": "{count, plural, =1{1 upcoming day change} other{{count} upcoming day changes}}!",
-  "dayChangesDialogTitle": "Upcoming day changes",
-  "dayChangesDialogSubtitle": "Resulting from academic calendar exceptions within the next {days} days:",
+  "incoming_days_changes_title": "{count, plural, =1{Upcoming day swap} other{{count} upcoming day swaps}}!",
+  "dayChangesDialogTitle": "Upcoming day swaps",
+  "dayChangesDialogSubtitle": "Resulting from the academic calendar day swaps within the next {days} days:",
   "dayChangesDialogOk": "OK",
-  "dayChangesDialogChangeFrom": "Change from an",
-  "dayChangesDialogChangeTo": "to an"
+  "day_changes_dialog_will_be": "Will be an",
+  "day_changes_dialog_instead_of": "instead of an"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -486,9 +486,15 @@
   "is_parking_set_maximum_vehicle_height": "{boolean, select, true{The maximum height of vehicles entering the parking lot is } false{There is no specified maximum vehicle height for entering the parking lot.} other{}}",
   "parking_permissions_types": "Access to the parking lot requires the following permissions: {numeric, select, 2{student or employee (university parking)} other{employee}}",
   "parking_are_spaces_for_pwd": "{boolean, select, true{There are designated parking spaces for people with disabilities. Number of available spaces: } false{There are no designated parking spaces for people with disabilities. } other{}}",
-  "parking_are_spaces_for_pwd_vertical_marked": "{boolean, select, true{Parking spaces for people with disabilities are marked with vertical signs.} false{Parking spaces for people with disabilities are not marked with vertical signs.} other{}}",  "is_multistorey_parking": "The parking lot is {boolean, select, true{multistorey. } other{single-storey. }}",
+  "parking_are_spaces_for_pwd_vertical_marked": "{boolean, select, true{Parking spaces for people with disabilities are marked with vertical signs.} false{Parking spaces for people with disabilities are not marked with vertical signs.} other{}}",
+  "is_multistorey_parking": "The parking lot is {boolean, select, true{multistorey. } other{single-storey. }}",
   "parking_is_road_accessible_for_people_in_wheelchairs": "{boolean, select, true{The road from the parking space for people with disabilities to the building or elevator is accessible. } false{The road from the parking space for people with disabilities to the elevator is not accessible. } other{}}",
   "parking_shortest_length_to_nearest_spaces_for_pwd": "The entrance to the building or elevator in the underground parking lot is located {value} meters from the parking space for people with disabilities.",
   "button_leading_to": "Button leading to",
-  "logotype": "Logotype"
+  "logotype": "Logotype",
+  "next_changed_day_prefix": "Next day change in ",
+  "next_changed_day_days": " days (",
+  "next_changed_day_date_suffix": ") ",
+  "next_changed_day_from": " from ",
+  "next_changed_day_to": " to "
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -493,7 +493,7 @@
   "button_leading_to": "Button leading to",
   "logotype": "Logotype",
   "incoming_days_changes_days": "{days, plural, =1{1 day} other{{days} days}}",
-  "incoming_days_changes_title": "Upcoming {count, plural, =1{1 day change} other{{count} day changes}}!",
+  "incoming_days_changes_title": "{count, plural, =1{1 upcoming day change} other{{count} upcoming day changes}}!",
   "dayChangesDialogTitle": "Upcoming day changes",
   "dayChangesDialogSubtitle": "Resulting from academic calendar exceptions within the next {days} days:",
   "dayChangesDialogOk": "OK",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -498,5 +498,19 @@
   "dayChangesDialogSubtitle": "Resulting from the academic calendar day swaps within the next {days} days:",
   "dayChangesDialogOk": "OK",
   "day_changes_dialog_will_be": "Will be an",
-  "day_changes_dialog_instead_of": "instead of an"
+  "day_changes_dialog_instead_of": "instead of an",
+  "even_monday_declined": "Even Monday",
+  "even_tuesday_declined": "Even Tuesday",
+  "even_wednesday_declined": "Even Wednesday",
+  "even_thursday_declined": "Even Thursday",
+  "even_friday_declined": "Even Friday",
+  "even_saturday_declined": "Even Saturday",
+  "even_sunday_declined": "Even Sunday",
+  "odd_monday_declined": "Odd Monday",
+  "odd_tuesday_declined": "Odd Tuesday",
+  "odd_wednesday_declined": "Odd Wednesday",
+  "odd_thursday_declined": "Odd Thursday",
+  "odd_friday_declined": "Odd Friday",
+  "odd_saturday_declined": "Odd Saturday",
+  "odd_sunday_declined": "Odd Sunday"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -493,23 +493,10 @@
   "button_leading_to": "Button leading to",
   "logotype": "Logotype",
   "incoming_days_changes_days": "{days, plural, =1{1 day} other{{days} days}}",
-  "@incoming_days_changes_days": {
-    "description": "Number of days until first change in academic calendar",
-    "placeholders": {
-      "days": {
-        "type": "int",
-        "example": "5"
-      }
-    }
-  },
-  "incoming_days_changes_title": "Incoming {count, plural, =1{1 day change} other{{count} day changes}}!",
-  "@incoming_days_changes_title": {
-    "description": "Title showing number of incoming day changes in academic calendar",
-    "placeholders": {
-      "count": {
-        "type": "int",
-        "example": "3"
-      }
-    }
-  }
+  "incoming_days_changes_title": "Upcoming {count, plural, =1{1 day change} other{{count} day changes}}!",
+  "dayChangesDialogTitle": "Upcoming day changes",
+  "dayChangesDialogSubtitle": "Resulting from academic calendar exceptions within the next {days} days:",
+  "dayChangesDialogOk": "OK",
+  "dayChangesDialogChangeFrom": "Change from an",
+  "dayChangesDialogChangeTo": "to an"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -492,9 +492,24 @@
   "parking_shortest_length_to_nearest_spaces_for_pwd": "The entrance to the building or elevator in the underground parking lot is located {value} meters from the parking space for people with disabilities.",
   "button_leading_to": "Button leading to",
   "logotype": "Logotype",
-  "next_changed_day_prefix": "Next day change in ",
-  "next_changed_day_days": " days (",
-  "next_changed_day_date_suffix": ") ",
-  "next_changed_day_from": " from ",
-  "next_changed_day_to": " to "
+  "incoming_days_changes_days": "{days, plural, =1{1 day} other{{days} days}}",
+  "@incoming_days_changes_days": {
+    "description": "Number of days until first change in academic calendar",
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "incoming_days_changes_title": "Incoming {count, plural, =1{1 day change} other{{count} day changes}}!",
+  "@incoming_days_changes_title": {
+    "description": "Title showing number of incoming day changes in academic calendar",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3069,24 +3069,24 @@
   "@logotype": {
     "description": "information about some logotype"
   },
-  "next_changed_day_prefix": "Następna zamiana dnia już za ",
-  "@next_changed_day_prefix": {
-    "description": "Prefix for the next day change countdown, showing how many days are left"
+  "incoming_days_changes_days": "{days, plural, =1{1 dzień}  other{{days} dni}}",
+  "@incoming_days_changes_days": {
+    "description": "Liczba dni do pierwszej zmiany w kalendarzu akademickim",
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "5"
+      }
+    }
   },
-  "next_changed_day_days": " dni (",
-  "@next_changed_day_days": {
-    "description": "Text for days unit in the countdown"
-  },
-  "next_changed_day_date_suffix": ") ",
-  "@next_changed_day_date_suffix": {
-    "description": "Suffix after the date in parentheses"
-  },
-  "next_changed_day_from": " z ",
-  "@next_changed_day_from": {
-    "description": "Text indicating the change from one day to another"
-  },
-  "next_changed_day_to": " na ",
-  "@next_changed_day_to": {
-    "description": "Text indicating the change to a new day"
+  "incoming_days_changes_title": "{count, plural, =1{Nadchodząca} other{Nadchodzące}} {count, plural, =1{zamiana dnia} other{{count} zamiany dni}}!",
+  "@incoming_days_changes_title": {
+    "description": "Tytuł pokazujący liczbę nadchodzących zmian dnia w kalendarzu akademickim",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -2985,12 +2985,10 @@
   "@select": {
     "description": "Button text for language selection on first launch"
   },
-
-  "parking_entry_location" : "Wjazd na parking znajduje się ", 
+  "parking_entry_location": "Wjazd na parking znajduje się ",
   "@parking_entry_location": {
     "description": "Label for parking entry location"
   },
-
   "is_parking_entry_from_ground_level": "Parking {boolean, select, false{nie } other{}}znajduje się na poziomie jezdni.",
   "@is_parking_entry_from_ground_level": {
     "description": "Information about level of parking",
@@ -3000,7 +2998,6 @@
       }
     }
   },
-
   "is_parking_set_maximum_vehicle_height": "{boolean, select, true{Maksymalna wysokość pojazdu wjeżdżającego na parking wynosi } false{Nie ma określonej maksymalnej wysokości pojazdu wjeżdżającego na parking.} other{}}",
   "@is_parking_set_maximum_vehicle_height": {
     "description": "Information about maximum allowed height of vehicle",
@@ -3010,7 +3007,6 @@
       }
     }
   },
-
   "parking_permissions_types": "Korzystanie z parkingu wymaga następujących uprawnień: {numeric, select, 2{student lub pracownik (parking uczelniany)} other{pracownik}}",
   "@parking_permissions_types": {
     "description": "Information about who can access the parking",
@@ -3020,7 +3016,6 @@
       }
     }
   },
-
   "parking_are_spaces_for_pwd": "{boolean, select, true{Na parkingu wydzielone są miejsca dla osób z niepełnosprawnościami. Liczba dostępnych miejsc: } false{Na parkingu nie ma wydzielonych miejsc dla osób z niepełnosprawnościami. } other{}}",
   "@parking_are_spaces_for_pwd": {
     "description": "Information about spaces for people with disabilities",
@@ -3030,7 +3025,6 @@
       }
     }
   },
-
   "parking_are_spaces_for_pwd_vertical_marked": "{boolean, select, true{Miejsca parkingowe dla osób z niepełnosprawnościami są oznaczone znakami pionowymi.} false{Miejsca parkingowe dla osób z niepełnosprawnościami nie są oznaczone znakami pionowymi.} other{}}",
   "@parking_are_spaces_for_pwd_vertical_marked": {
     "description": "Information if parking spaces for people with disabilities are marked with vertical signs",
@@ -3040,7 +3034,6 @@
       }
     }
   },
-
   "is_multistorey_parking": "Parking jest {boolean, select, true{wielopoziomowy. } other{jednopoziomowy. }}",
   "@is_multistorey_parking": {
     "description": "Information if parking is multistorey",
@@ -3050,7 +3043,6 @@
       }
     }
   },
-
   "parking_is_road_accessible_for_people_in_wheelchairs": "{boolean, select, true{Droga od miejsca parkingowego dla osób z niepełnosprawnościami do budynku lub windy jest dostępna. } false{Droga od miejsca parkingowego dla osób z niepełnosprawnościami do windy nie jest dostępna. } other{}}",
   "@parking_is_road_accessible_for_people_in_wheelchairs": {
     "description": "Information if road from parking to building is accessible for people on wheelchairs",
@@ -3060,7 +3052,6 @@
       }
     }
   },
-
   "parking_shortest_length_to_nearest_spaces_for_pwd": "Wejście do budynku lub windy w parkingu podziemnym znajduje się w odległości {value} metrów od miejsca parkingowego dla osób z niepełnosprawnościami. ",
   "@parking_shortest_length_to_nearest_spaces_for_pwd": {
     "description": "information on how far the disabled parking lot is from the building",
@@ -3070,14 +3061,32 @@
       }
     }
   },
-
   "button_leading_to": "Przycisk prowadzący do",
-  "@button_leading_to":{
+  "@button_leading_to": {
     "description": "information about url the button is redirecting to"
   },
   "logotype": "Logotyp",
-  "@logotype":{
+  "@logotype": {
     "description": "information about some logotype"
+  },
+  "next_changed_day_prefix": "Następna zamiana dnia już za ",
+  "@next_changed_day_prefix": {
+    "description": "Prefix for the next day change countdown, showing how many days are left"
+  },
+  "next_changed_day_days": " dni (",
+  "@next_changed_day_days": {
+    "description": "Text for days unit in the countdown"
+  },
+  "next_changed_day_date_suffix": ") ",
+  "@next_changed_day_date_suffix": {
+    "description": "Suffix after the date in parentheses"
+  },
+  "next_changed_day_from": " z ",
+  "@next_changed_day_from": {
+    "description": "Text indicating the change from one day to another"
+  },
+  "next_changed_day_to": " na ",
+  "@next_changed_day_to": {
+    "description": "Text indicating the change to a new day"
   }
-  
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3114,5 +3114,61 @@
   "day_changes_dialog_instead_of": "zamiast",
   "@day_changes_dialog_instead_of": {
     "description": "Text indicating the day that will be changed to"
+  },
+  "even_monday_declined": "Parzystego Poniedziałku",
+  "@even_monday_declined": {
+    "description": "Text shown for even week Monday"
+  },
+  "even_tuesday_declined": "Parzystego Wtorku",
+  "@even_tuesday_declined": {
+    "description": "Text shown for even week Tuesday"
+  },
+  "even_wednesday_declined": "Parzystej Środy",
+  "@even_wednesday_declined": {
+    "description": "Text shown for even week Wednesday"
+  },
+  "even_thursday_declined": "Parzystego Czwartku",
+  "@even_thursday_declined": {
+    "description": "Text shown for even week Thursday"
+  },
+  "even_friday_declined": "Parzystego Piątku",
+  "@even_friday_declined": {
+    "description": "Text shown for even week Friday"
+  },
+  "even_saturday_declined": "Parzystej Soboty",
+  "@even_saturday_declined": {
+    "description": "Text shown for even week Saturday"
+  },
+  "even_sunday_declined": "Parzystej Niedzieli",
+  "@even_sunday_declined": {
+    "description": "Text shown for even week Sunday"
+  },
+  "odd_monday_declined": "Nieparzystego Poniedziałku",
+  "@odd_monday_declined": {
+    "description": "Text shown for odd week Monday"
+  },
+  "odd_tuesday_declined": "Nieparzystego Wtorku",
+  "@odd_tuesday_declined": {
+    "description": "Text shown for odd week Tuesday"
+  },
+  "odd_wednesday_declined": "Nieparzystej Środy",
+  "@odd_wednesday_declined": {
+    "description": "Text shown for odd week Wednesday"
+  },
+  "odd_thursday_declined": "Nieparzystego Czwartku",
+  "@odd_thursday_declined": {
+    "description": "Text shown for odd week Thursday"
+  },
+  "odd_friday_declined": "Nieparzystego Piątku",
+  "@odd_friday_declined": {
+    "description": "Text shown for odd week Friday"
+  },
+  "odd_saturday_declined": "Nieparzystej Soboty",
+  "@odd_saturday_declined": {
+    "description": "Text shown for odd week Saturday"
+  },
+  "odd_sunday_declined": "Nieparzystej Niedzieli",
+  "@odd_sunday_declined": {
+    "description": "Text shown for odd week Sunday"
   }
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -145,7 +145,7 @@
   "@unknown_day": {
     "description": "Fallback text when day type is unknown"
   },
-  "read_more": "Czytaj dalej",
+  "read_more": "Czytaj więcej",
   "@read_more": {
     "description": "Button text to expand content"
   },
@@ -3071,7 +3071,7 @@
   },
   "incoming_days_changes_days": "{days, plural, =1{1 dzień}  other{{days} dni}}",
   "@incoming_days_changes_days": {
-    "description": "Liczba dni do pierwszej zmiany w kalendarzu akademickim",
+    "description": "Number of days until first change in academic calendar",
     "placeholders": {
       "days": {
         "type": "int",
@@ -3081,12 +3081,38 @@
   },
   "incoming_days_changes_title": "{count, plural, =1{Nadchodząca} other{Nadchodzące}} {count, plural, =1{zamiana dnia} other{{count} zamiany dni}}!",
   "@incoming_days_changes_title": {
-    "description": "Tytuł pokazujący liczbę nadchodzących zmian dnia w kalendarzu akademickim",
+    "description": "Title showing number of incoming day changes in academic calendar",
     "placeholders": {
       "count": {
         "type": "int",
         "example": "3"
       }
     }
+  },
+  "dayChangesDialogTitle": "Nadchodzące zamiany dni",
+  "@dayChangesDialogTitle": {
+    "description": "Title of the dialog showing upcoming academic calendar day changes"
+  },
+  "dayChangesDialogSubtitle": "Wynikające z wyjątków w kalendarzu akademickim w ciągu następnych {days} dni:",
+  "@dayChangesDialogSubtitle": {
+    "description": "Subtitle of the dialog showing the time window for academic calendar changes",
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "7"
+      }
+    }
+  },
+  "dayChangesDialogOk": "OK",
+  "@dayChangesDialogOk": {
+    "description": "Button text to close the day changes dialog"
+  },
+  "day_changes_dialog_will_be": "Będzie",
+  "@day_changes_dialog_will_be": {
+    "description": "Text indicating the day that will be changed"
+  },
+  "day_changes_dialog_instead_of": "zamiast",
+  "@day_changes_dialog_instead_of": {
+    "description": "Text indicating the day that will be changed to"
   }
 }

--- a/lib/utils/datetime_utils.dart
+++ b/lib/utils/datetime_utils.dart
@@ -11,13 +11,19 @@ extension DateTimeUtilsX on DateTime {
     return subtract(Duration(days: difference));
   }
 
-  String toDayDateString(BuildContext context) {
+  String toDayDateString(BuildContext context, {bool includeWeekday = true, bool includeYear = true}) {
     final dayFormat = DateFormat("EEEE", context.locale.languageCode);
-    final dateFormat = DateFormat("dd.MM.yyyy", context.locale.languageCode);
+    final dateFormat =
+        includeYear
+            ? DateFormat("dd.MM.yyyy", context.locale.languageCode)
+            : DateFormat("dd.MM", context.locale.languageCode);
     final day = dayFormat.format(this);
     final capitalizedDay = day[0].toUpperCase() + day.substring(1).toLowerCase();
     final date = dateFormat.format(this);
-    return "$capitalizedDay, $date";
+    if (includeWeekday) {
+      return "$capitalizedDay, $date";
+    }
+    return date;
   }
 
   String toHourMinuteString(BuildContext context) {

--- a/lib/widgets/my_alert_dialog.dart
+++ b/lib/widgets/my_alert_dialog.dart
@@ -6,7 +6,7 @@ import "../../../utils/context_extensions.dart";
 
 Future<void> showCustomDialog({
   required BuildContext context,
-  required void Function(BuildContext context) onConfirmTapped,
+  required void Function(BuildContext context)? onConfirmTapped,
   required String confirmText,
   required Widget dialogContent,
 }) async {
@@ -19,7 +19,7 @@ Future<void> showCustomDialog({
           constraints: BoxConstraints(maxWidth: maxWidth),
           child: _MyAlertDialog(
             dialogContent: dialogContent,
-            onConfirmTapped: () => onConfirmTapped(context),
+            onConfirmTapped: onConfirmTapped != null ? () => onConfirmTapped(context) : null,
             confirmText: confirmText,
           ),
         ),
@@ -30,10 +30,10 @@ Future<void> showCustomDialog({
 
 class _MyAlertDialog extends StatelessWidget {
   final Widget dialogContent;
-  final VoidCallback onConfirmTapped;
+  final VoidCallback? onConfirmTapped;
   final String confirmText;
 
-  const _MyAlertDialog({required this.dialogContent, required this.onConfirmTapped, required this.confirmText});
+  const _MyAlertDialog({required this.dialogContent, this.onConfirmTapped, required this.confirmText});
 
   @override
   Widget build(BuildContext context) {
@@ -49,15 +49,16 @@ class _MyAlertDialog extends StatelessWidget {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            Flexible(
-              child: TextButton(
-                onPressed: onConfirmTapped,
-                child: Text(
-                  confirmText,
-                  style: context.textTheme.bodyOrange.copyWith(fontSize: AlertDialogConfig.buttonFontSize),
+            if (onConfirmTapped != null)
+              Flexible(
+                child: TextButton(
+                  onPressed: onConfirmTapped,
+                  child: Text(
+                    confirmText,
+                    style: context.textTheme.bodyOrange.copyWith(fontSize: AlertDialogConfig.buttonFontSize),
+                  ),
                 ),
               ),
-            ),
             Flexible(
               child: TextButton(
                 child: Text(

--- a/lib/widgets/my_splash_tile.dart
+++ b/lib/widgets/my_splash_tile.dart
@@ -4,11 +4,11 @@ import "../config/ui_config.dart";
 import "../theme/app_theme.dart";
 
 class MySplashTile extends StatelessWidget {
-  const MySplashTile({super.key, required this.child, this.onTap});
+  const MySplashTile({super.key, required this.child, this.onTap, this.backgroundColor});
 
   final Widget child;
   final VoidCallback? onTap;
-
+  final Color? backgroundColor;
   @override
   Widget build(BuildContext context) {
     return Material(
@@ -18,7 +18,7 @@ class MySplashTile extends StatelessWidget {
         onTap: onTap,
         child: Ink(
           decoration: BoxDecoration(
-            color: context.colorTheme.greyLight,
+            color: backgroundColor ?? context.colorTheme.greyLight,
             borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
           ),
           child: child,

--- a/lib/widgets/technical_message.dart
+++ b/lib/widgets/technical_message.dart
@@ -18,6 +18,7 @@ class TechnicalMessage extends StatelessWidget {
     this.backgoundColor,
     this.textColor,
     this.translate = false,
+    this.padding,
   });
   final String message;
   final String? title;
@@ -28,10 +29,11 @@ class TechnicalMessage extends StatelessWidget {
   final Color? backgoundColor;
   final Color? textColor;
   final bool translate;
+  final EdgeInsets? padding;
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(HomeViewConfig.paddingMedium),
+      padding: padding ?? const EdgeInsets.all(HomeViewConfig.paddingMedium),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(AppWidgetsConfig.borderRadiusMedium),
         child: ColoredBox(


### PR DESCRIPTION
Feature discussed today on discord: https://discord.com/channels/687360174377533442/1305494727679938613/1368550410494804028


also changed paddings and logic with the planer advert banner (and now dialog).
The number of days it looks for in the future is configurable on directus.

# normal view
![Simulator Screenshot - iPhone 16 Plus - 2025-05-04 at 18 28 27](https://github.com/user-attachments/assets/6cd49bc6-e800-4e6e-9943-8d2ba343fdc0)

# Just banner (as before)
![simulator_screenshot_64D0A8E5-87F3-4A4B-9E4D-8AFC42869DC7](https://github.com/user-attachments/assets/c2448e1c-4a0c-4fda-9e4c-a558d58626c5)

# Just upcoming days alert (the lookup window will be changed to 7 days, currently is 30 days for testing)
## PL
![simulator_screenshot_FF1722CB-72A3-4066-8A6C-93E7F8F60C54](https://github.com/user-attachments/assets/ce26f865-ff4b-4b1e-8aa2-cca5b776c04b)
## EN
![simulator_screenshot_85B543D7-8982-4BE4-9BE7-FD86885FEDDC](https://github.com/user-attachments/assets/4a49da2f-060f-4b18-8f7d-b694689eafe7)

# Both, upcoming days alert and banner (changed to top right corner badge - color is also configurable)
![simulator_screenshot_82876E30-CCAD-46DF-BF71-666F8BF6FCF8](https://github.com/user-attachments/assets/a38ec711-2f87-4dbd-98da-e43aeba9ef90)

# Ad banner in the dialog form (when the days alert is also visible) - also added missing translation for the banner
## PL
![simulator_screenshot_79049993-3D0E-44A1-8CBE-0BFC3C9B7717](https://github.com/user-attachments/assets/1f3bcd22-e3df-489e-af25-411c4f95998a)
## EN
![simulator_screenshot_861F7FFC-6528-4194-9B57-03F40CADB355](https://github.com/user-attachments/assets/c9047508-aa0f-40ba-b401-978cb2d2636c)

# Upcoming changes dialog
## PL
![simulator_screenshot_ADFBE8CB-E856-4C56-90E3-0FB5360DDBE7](https://github.com/user-attachments/assets/b4f0ed11-5ea0-42ab-8041-1e3bd3167950)
## EN
![simulator_screenshot_3C9AE3C6-9A6C-4446-8723-FF56CA7F691E](https://github.com/user-attachments/assets/e23978cc-fcf2-448a-80c7-1fbab9462d23)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implements an alert system for upcoming academic day changes with configurable settings and enhanced UI components.
> 
>   - **Behavior**:
>     - Adds `IncomingDayChanges` widget to display alerts for upcoming day changes in `academic_calendar_consumer.dart`.
>     - Introduces `DayChangesDialog` in `day_changes_dialog.dart` to show detailed information about upcoming day changes.
>     - Configurable future window for day change alerts via `exceptionsLookupFutureWindowInDays` in `schema.graphql`.
>   - **UI Components**:
>     - Updates `HomeView` to include `PlannerBannerVisibility` and `PlanerAdBadge` for planner advertisements.
>     - Modifies `RedDialog` in `red_dialog.dart` to optionally hide the close button.
>     - Adjusts padding in `ui_config.dart` for consistent UI spacing.
>   - **Localization**:
>     - Adds new localization strings for day change alerts in `app_en.arb` and `app_pl.arb`.
>   - **Misc**:
>     - Renames `AcademicWeekException` to `AcademicDaySwap` in `academic_calendar_repo.dart` and related files.
>     - Enhances `DateTimeUtilsX` in `datetime_utils.dart` with new date formatting options.
>     - Updates `my_alert_dialog.dart` to handle optional confirm actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 69da090cd37ac4719599deea825661ea6f46aeae. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->