### PR TITLE
fix(about-us): restore touch for team members list

### DIFF
--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -88,7 +88,7 @@ class _SingleVersionTeamList extends HookWidget {
         showLoader.value = false;
       });
       return timer.cancel;
-    }, [version]);
+    }, [version, shimmerTime]);
 
     final double expectedHeight =
         version.members.isEmpty ? 100.0 : version.members.length * WideTileCardConfig.imageSize;

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -73,57 +73,22 @@ class _SelectTab extends StatelessWidget {
   }
 }
 
-class _SingleVersionTeamList extends StatefulWidget {
+class _SingleVersionTeamList extends HookWidget {
   const _SingleVersionTeamList({required this.version, required this.shimmerTime});
 
   final MultiversionTeam version;
   final int shimmerTime;
 
   @override
-  _SingleVersionTeamListState createState() => _SingleVersionTeamListState();
-}
-
-class _SingleVersionTeamListState extends State<_SingleVersionTeamList> {
-  bool _showLoader = true;
-  Timer? _timer;
-
-  @override
-  void initState() {
-    super.initState();
-    _startLoaderTimer();
-  }
-
-  @override
-  void didUpdateWidget(covariant _SingleVersionTeamList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.version != widget.version) {
-      setState(() {
-        _showLoader = true;
-      });
-      _startLoaderTimer();
-    }
-  }
-
-  void _startLoaderTimer() {
-    _timer?.cancel();
-    _timer = Timer(Duration(milliseconds: widget.shimmerTime), () {
-      if (mounted) {
-        setState(() {
-          _showLoader = false;
-        });
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final version = widget.version;
+    final showLoader = useState(true);
+    useEffect(() {
+      showLoader.value = true;
+      final timer = Timer(Duration(milliseconds: shimmerTime), () {
+        showLoader.value = false;
+      });
+      return timer.cancel;
+    }, [version]);
 
     final double expectedHeight =
         version.members.isEmpty ? 100.0 : version.members.length * WideTileCardConfig.imageSize;
@@ -152,7 +117,7 @@ class _SingleVersionTeamListState extends State<_SingleVersionTeamList> {
           children: [
             content,
             AnimatedOpacity(
-              opacity: _showLoader ? 1.0 : 0.0,
+              opacity: showLoader.value ? 1.0 : 0.0,
               duration: const Duration(milliseconds: 1),
               child: ColoredBox(
                 color: context.colorTheme.whiteSoap,

--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -111,25 +111,19 @@ class _SingleVersionTeamList extends HookWidget {
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AboutUsConfig.defaultPadding),
-      child: SizedBox(
-        height: expectedHeight,
-        child: Stack(
-          children: [
-            content,
-            AnimatedOpacity(
-              opacity: showLoader.value ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 1),
-              child: ColoredBox(
-                color: context.colorTheme.whiteSoap,
-                child: const Align(
-                  alignment: Alignment.topCenter,
-                  child: Padding(padding: EdgeInsets.only(top: 16), child: CircularProgressIndicator()),
+      child:
+          showLoader.value
+              ? SizedBox(
+                height: expectedHeight,
+                child: ColoredBox(
+                  color: context.colorTheme.whiteSoap,
+                  child: const Align(
+                    alignment: Alignment.topCenter,
+                    child: Padding(padding: EdgeInsets.only(top: 16), child: CircularProgressIndicator()),
+                  ),
                 ),
-              ),
-            ),
-          ],
-        ),
-      ),
+              )
+              : content,
     );
   }
 }
@@ -201,27 +195,25 @@ class _Description extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(name, style: context.aboutUsTheme.headlineSmaller, softWrap: true),
-            const SizedBox(height: 4),
-            Text(subtitle, style: context.aboutUsTheme.bodySmaller, softWrap: true),
-            const SizedBox(height: 8),
-            Row(
-              children: [
-                for (final icon in links)
-                  Semantics(
-                    label: "${context.localize.button_leading_to}: ${Uri.parse(icon.url ?? "").host}",
-                    child: _Icon(launchUrl: icon.url ?? "", icon: icon.icon),
-                  ),
-              ],
-            ),
-          ],
-        ),
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(name, style: context.aboutUsTheme.headlineSmaller, softWrap: true),
+          const SizedBox(height: 4),
+          Text(subtitle, style: context.aboutUsTheme.bodySmaller, softWrap: true),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              for (final icon in links)
+                Semantics(
+                  label: "${context.localize.button_leading_to}: ${Uri.parse(icon.url ?? "").host}",
+                  child: _Icon(launchUrl: icon.url ?? "", icon: icon.icon),
+                ),
+            ],
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
oh well, Rafał did cook, he did...

there was a 0 opacity layer above the list (in a Stack)

also did a refactor to flutter hooks.

I would consider changing this later to shimmer loading 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes touch interaction issue on team members list and refactors `_SingleVersionTeamList` to use Flutter hooks.
> 
>   - **Behavior**:
>     - Fixes touch interaction issue on team members list by removing 0 opacity layer in `_SingleVersionTeamList`.
>   - **Refactor**:
>     - Converts `_SingleVersionTeamList` from `StatefulWidget` to `HookWidget` using `useState` and `useEffect` for state management.
>     - Removes `Expanded` widget from `_Description` class, simplifying the layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 8b023c8607aadd7f16bd12fa92b57b1691837f31. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->