### PR TITLE
feat(about-us): change loading to shimmer one

### DIFF
--- a/lib/features/about_us_view/widgets/team_section.dart
+++ b/lib/features/about_us_view/widgets/team_section.dart
@@ -12,6 +12,8 @@ import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../utils/determine_contact_icon.dart";
 import "../../../utils/launch_url_util.dart";
+import "../../../widgets/loading_widgets/scrolable_loader_builder.dart";
+import "../../../widgets/loading_widgets/simple_previews/preview_card_loading.dart";
 import "../../../widgets/zoomable_images.dart";
 import "../models/about_us_details.dart";
 import "../models/member_data.dart";
@@ -111,19 +113,28 @@ class _SingleVersionTeamList extends HookWidget {
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AboutUsConfig.defaultPadding),
-      child:
-          showLoader.value
-              ? SizedBox(
-                height: expectedHeight,
-                child: ColoredBox(
-                  color: context.colorTheme.whiteSoap,
-                  child: const Align(
-                    alignment: Alignment.topCenter,
-                    child: Padding(padding: EdgeInsets.only(top: 16), child: CircularProgressIndicator()),
-                  ),
-                ),
-              )
-              : content,
+      child: showLoader.value ? _TeamMembersLoading(expectedHeight: expectedHeight) : content,
+    );
+  }
+}
+
+class _TeamMembersLoading extends StatelessWidget {
+  const _TeamMembersLoading({required this.expectedHeight});
+
+  final double expectedHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: expectedHeight,
+      child: ScrollableLoaderBuilder(
+        itemsSpacing: 16,
+        scrollDirection: Axis.vertical,
+        mainAxisItemSize: 12,
+        itemBuilder: (BuildContext context, int index) {
+          return const PreviewCardLoading(width: double.infinity, height: AboutUsConfig.photoSize);
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/41c89850-f04d-4d7f-a994-0cd9b02702f5


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `CircularProgressIndicator` with shimmer loading effect in `about_us_view` using `ScrollableLoaderBuilder` and `PreviewCardLoading`.
> 
>   - **Behavior**:
>     - Replaces `CircularProgressIndicator` with shimmer effect in `_SingleVersionTeamList` in `team_section.dart`.
>     - Uses `ScrollableLoaderBuilder` and `PreviewCardLoading` for shimmer effect.
>   - **Components**:
>     - Adds `_TeamMemebersLoading` class to handle shimmer loading.
>     - Modifies `_SingleVersionTeamList` to use `_TeamMemebersLoading` when `showLoader` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 9fedd118d02cd8d8e1f0f7f3365c5533196e91ca. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->