### PR TITLE
feat(buildings): add accessibility for building screen list

### DIFF
--- a/lib/features/bottom_scroll_sheet/bottom_scroll_sheet.dart
+++ b/lib/features/bottom_scroll_sheet/bottom_scroll_sheet.dart
@@ -20,13 +20,14 @@ class BottomScrollSheet<T extends GoogleNavigable> extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        final scaler = context.textScaler.clamp(maxScaleFactor: 1.5);
         final screenHeight = constraints.maxHeight;
         final sheetSize = context.mapSheetSize<T>();
 
         final isAnyActive = ref.watch(context.activeMarkerController<T>()) != null;
-        final recommendedSheetHeight =
-            isAnyActive ? sheetSize.recomendedActiveSheetHeight : sheetSize.recomendedSheetHeight;
-
+        final recommendedSheetHeight = scaler.scale(
+          isAnyActive ? sheetSize.recomendedActiveSheetHeight : sheetSize.recomendedSheetHeight,
+        );
         final minSheetHeight = sheetSize.minSheetHeight;
 
         final double recommendedSheetFraction = min(1, recommendedSheetHeight / screenHeight);

--- a/lib/features/bottom_scroll_sheet/navigate_button.dart
+++ b/lib/features/bottom_scroll_sheet/navigate_button.dart
@@ -19,7 +19,11 @@ class NavigateButton<T extends GoogleNavigable> extends ConsumerWidget {
         icon: Icon(ParkingsIcons.map_nav, color: context.colorTheme.orangePomegranade, size: 16),
         onPressed: ref.watch(context.activeMarkerController<T>().notifier).launchLink,
         style: TextButton.styleFrom(padding: const EdgeInsets.all(12)),
-        label: Text(context.localize.navigate, style: context.textTheme.boldBodyOrange),
+        label: Text(
+          context.localize.navigate,
+          style: context.textTheme.boldBodyOrange,
+          textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
+        ),
       ),
     );
   }

--- a/lib/features/buildings_view/building_tile.dart
+++ b/lib/features/buildings_view/building_tile.dart
@@ -33,8 +33,8 @@ class BuildingTile extends HookConsumerWidget {
       messageBuilder:
           (active) =>
               active
-                  ? "${l10n.building_tile_selected} ${l10n.building_tile_building} ${building.name}"
-                  : "${l10n.building_tile_unselected} ${l10n.building_tile_building} ${building.name}",
+                  ? "${l10n.building_tile_selected} ${l10n.building_tile_building} ${building.name.replaceFirst("-", " ")}"
+                  : "${l10n.building_tile_unselected} ${l10n.building_tile_building} ${building.name.replaceFirst("-", " ")}",
     );
 
     return Column(
@@ -43,7 +43,7 @@ class BuildingTile extends HookConsumerWidget {
           children: [
             Semantics(
               label:
-                  "${isActive ? "${context.localize.building_tile_selected} " : ""}${context.localize.building_tile_building} ${building.name}. ${context.localize.building_tile_address}: ${building.addressFormatted}. ${hasDigitalGuide ? context.localize.building_tile_digital_guide_available : ""}",
+                  "${isActive ? "${context.localize.building_tile_selected} " : ""}${context.localize.building_tile_building} ${building.name.replaceFirst("-", " ")}. ${context.localize.building_tile_address}: ${building.addressFormatted}. ${hasDigitalGuide ? context.localize.building_tile_digital_guide_available : ""}",
               button: true,
               child: ExcludeSemantics(
                 child: PhotoTrailingWideTileCard(
@@ -56,13 +56,14 @@ class BuildingTile extends HookConsumerWidget {
                   onTap: () {
                     unawaited(ref.read(buildingsMapControllerProvider).onMarkerTap(building));
                   },
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                 ),
               ),
             ),
             if (building.externalDigitalGuideMode != null && building.externalDigitalGuideIdOrURL != null)
               Positioned(
-                top: 2,
-                right: WideTileCardConfig.imageSize + 2,
+                top: context.textScaler.scale(2),
+                right: WideTileCardConfig.imageSize + context.textScaler.scale(2),
                 child: IconButton(
                   tooltip: switch (building.externalDigitalGuideMode) {
                     "digital_guide_building" ||
@@ -73,7 +74,7 @@ class BuildingTile extends HookConsumerWidget {
                           : context.localize.external_link(building.externalDigitalGuideIdOrURL!),
                     _ => null,
                   },
-                  iconSize: 22,
+                  iconSize: context.textScaler.clamp(maxScaleFactor: 2).scale(22),
                   visualDensity: VisualDensity.compact,
                   color: switch (building.externalDigitalGuideMode) {
                     "digital_guide_building" || "other_digital_guide_place" => context.colorTheme.orangePomegranade,
@@ -108,12 +109,20 @@ class BuildingTile extends HookConsumerWidget {
             (building.externalDigitalGuideMode == "digital_guide_building" ||
                 building.externalDigitalGuideMode == "other_digital_guide_place"))
           TextButton.icon(
-            icon: Icon(Icons.accessibility_new_rounded, color: context.colorTheme.orangePomegranade, size: 16),
+            icon: Icon(
+              Icons.accessibility_new_rounded,
+              color: context.colorTheme.orangePomegranade,
+              size: context.textScaler.scale(16),
+            ),
             onPressed: () {
               unawaited(ref.navigateBuildingDetailAction(building));
             },
             style: TextButton.styleFrom(padding: const EdgeInsets.all(12)),
-            label: Text(context.localize.navigate_to_digital_guide, style: context.textTheme.boldBodyOrange),
+            label: Text(
+              context.localize.navigate_to_digital_guide,
+              style: context.textTheme.boldBodyOrange,
+              textAlign: TextAlign.center,
+            ),
           ),
       ],
     );

--- a/lib/features/map_view/widgets/map_widget.dart
+++ b/lib/features/map_view/widgets/map_widget.dart
@@ -6,6 +6,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 
 import "../../../config/map_view_config.dart";
 import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "../../my_location_button/presentation/is_following_controller.dart";
 import "../../my_location_button/presentation/my_loc_layer.dart";
 import "../controllers/controllers_set.dart";
@@ -41,11 +42,11 @@ class MapWidget<T extends GoogleNavigable> extends HookConsumerWidget {
           ),
           mapController: controller.mapController,
           children: [
-            const MapTileLayer(),
-            MarkersConsumerLayer<T>(),
-            const MyLocationLayer(),
+            Semantics(label: context.localize.map_view_description, child: const MapTileLayer()),
+            ExcludeSemantics(child: MarkersConsumerLayer<T>()),
+            const ExcludeSemantics(child: MyLocationLayer()),
             const Toolbar(),
-            const OpenMapAtrribution(),
+            const ExcludeSemantics(child: OpenMapAtrribution()),
           ],
         );
       },

--- a/lib/features/my_location_button/presentation/my_loc_button.dart
+++ b/lib/features/my_location_button/presentation/my_loc_button.dart
@@ -14,7 +14,7 @@ class MyLocationButton extends ConsumerWidget {
       tooltip: context.localize.my_location_button_tooltip,
       backgroundColor: context.colorTheme.whiteSoap,
       onPressed: ref.watch(isFollowingCurrentLocationControllerProvider.notifier).buttonClicked,
-      child: Icon(Icons.my_location, color: context.colorTheme.orangePomegranade),
+      child: Icon(Icons.my_location, color: context.colorTheme.orangePomegranade, size: 24),
     );
   }
 }

--- a/lib/features/my_location_button/presentation/my_loc_button.dart
+++ b/lib/features/my_location_button/presentation/my_loc_button.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
 import "is_following_controller.dart";
 
 class MyLocationButton extends ConsumerWidget {
@@ -10,6 +11,7 @@ class MyLocationButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return FloatingActionButton.small(
+      tooltip: context.localize.my_location_button_tooltip,
       backgroundColor: context.colorTheme.whiteSoap,
       onPressed: ref.watch(isFollowingCurrentLocationControllerProvider.notifier).buttonClicked,
       child: Icon(Icons.my_location, color: context.colorTheme.orangePomegranade),

--- a/lib/features/offline_messages/widgets/general_offline_message.dart
+++ b/lib/features/offline_messages/widgets/general_offline_message.dart
@@ -27,8 +27,8 @@ class OfflineMessage extends StatelessWidget {
           padding: const EdgeInsets.all(8),
           child: Lottie.asset(
             Assets.animations.offline,
-            width: 50,
-            height: 50,
+            width: context.textScaler.scale(50),
+            height: context.textScaler.scale(50),
             frameRate: const FrameRate(LottieAnimationConfig.frameRate),
             renderCache: RenderCache.drawingCommands,
           ),

--- a/lib/features/science_club/science_clubs_view/widgets/science_clubs_info_dialog.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/science_clubs_info_dialog.dart
@@ -55,7 +55,7 @@ class ScienceClubInfoDialog extends StatelessWidget {
           Consumer(
             builder:
                 (context, ref, child) => RichText(
-                  textScaler: MediaQuery.textScalerOf(context),
+                  textScaler: context.textScaler,
                   text: TextSpan(
                     text: context.localize.add_club_contact_info,
                     style: context.textTheme.lightTitle,

--- a/lib/features/science_club/science_clubs_view/widgets/strategic_badge.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/strategic_badge.dart
@@ -17,11 +17,12 @@ class _StrategicBadgeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scaler = context.textScaler.clamp(maxScaleFactor: 2);
     return Tooltip(
       message: context.localize.strategicBadgeTooltip,
       child: Stack(
         children: [
-          Center(child: Icon(Icons.shield, size: 14, color: context.colorTheme.blueAzure)),
+          Center(child: Icon(Icons.shield, size: scaler.scale(14), color: context.colorTheme.blueAzure)),
           Align(
             alignment: const Alignment(0, -1 / 4),
             child: Text(context.localize.strategic_club_abbr, style: context.textTheme.bodyWhite.copyWith(fontSize: 6)),

--- a/lib/features/science_club/science_clubs_view/widgets/verified_badge.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/verified_badge.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 
 import "../../../../theme/app_theme.dart";
+import "../../../../utils/context_extensions.dart";
 
 class VerifiedBadge extends WidgetSpan {
   const VerifiedBadge()
@@ -16,11 +17,12 @@ class _VerifiedBadgeWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scaler = context.textScaler.clamp(maxScaleFactor: 2);
     return SizedBox.square(
-      dimension: 16,
+      dimension: scaler.scale(16),
       child: Padding(
         padding: const EdgeInsets.only(left: 4),
-        child: Icon(Icons.verified_sharp, size: 12, color: context.colorTheme.orangePomegranade),
+        child: Icon(Icons.verified_sharp, size: scaler.scale(12), color: context.colorTheme.orangePomegranade),
       ),
     );
   }

--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_header.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_header.dart
@@ -27,17 +27,17 @@ class SksChartHeader extends StatelessWidget {
               Text(
                 SksChartConfig.buildingCode,
                 style: context.textTheme.headline,
-                textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
               ),
               Text(
                 "${context.localize.street_abbreviation} ${SksChartConfig.sksAddress}",
                 style: context.textTheme.body,
-                textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
               ),
               Text(
                 SksChartConfig.sksPostalCode,
                 style: context.textTheme.body,
-                textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
               ),
             ],
           ),
@@ -51,7 +51,7 @@ class SksChartHeader extends StatelessWidget {
                 Text(
                   numberOfPeople,
                   style: context.textTheme.body.copyWith(fontSize: 18),
-                  textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                  textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
                 ),
                 const SizedBox(width: SksChartConfig.heightSmall),
                 trend?.icon ?? const SizedBox.shrink(),

--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_labels.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_labels.dart
@@ -16,7 +16,7 @@ class SksChartRightTiles extends AxisTitles {
           semanticsLabel: "${context.localize.number_of_people} ${context.localize.axis_vertical_screen_reader}",
           style: context.textTheme.body.copyWith(fontSize: 14, fontWeight: FontWeight.w400),
         ),
-        axisNameSize: MediaQuery.textScalerOf(context).scale(16),
+        axisNameSize: context.textScaler.scale(16),
         sideTitles: SideTitles(
           maxIncluded: false,
           reservedSize: 40,
@@ -41,7 +41,7 @@ class SksChartBottomTitles extends AxisTitles {
         sideTitles: SideTitles(
           showTitles: true,
           reservedSize: 35,
-          interval: MediaQuery.textScalerOf(context).scale(1) > 1 ? 40 : 5,
+          interval: context.isTextScaledDown ? 5 : 40,
           getTitlesWidget: (double value, TitleMeta meta) {
             final DateTime? hourMinute = chartData.isNotEmpty ? chartData[value.toInt()].externalTimestamp : null;
             final String hourMinuteFormatted =
@@ -52,7 +52,7 @@ class SksChartBottomTitles extends AxisTitles {
                 padding: const EdgeInsets.only(top: SksChartConfig.paddingSmall, left: 50),
                 child: Text(
                   style: context.textTheme.body.copyWith(fontSize: 12, fontWeight: FontWeight.w400),
-                  textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+                  textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
                   hourMinuteFormatted,
                 ),
               ),

--- a/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_legend.dart
+++ b/lib/features/sks/sks_chart/presentation/chart_elements/sks_chart_legend.dart
@@ -50,7 +50,7 @@ class SksChartLegendItem extends StatelessWidget {
             text,
             style: context.textTheme.body,
             softWrap: true,
-            textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.5),
+            textScaler: context.textScaler.clamp(maxScaleFactor: 1.5),
           ),
         ),
       ],

--- a/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
+++ b/lib/features/sks/sks_chart/presentation/sks_chart_sheet.dart
@@ -119,7 +119,7 @@ class _SksSheetHeader extends StatelessWidget {
             context.localize.sks_chart_title,
             style: context.textTheme.headline,
             textAlign: TextAlign.center,
-            textScaler: MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1.3),
+            textScaler: context.textScaler.clamp(maxScaleFactor: 1.3),
           ),
         ),
       ],

--- a/lib/features/sks/sks_menu/presentation/widgets/sks_menu_tiles.dart
+++ b/lib/features/sks/sks_menu/presentation/widgets/sks_menu_tiles.dart
@@ -6,6 +6,7 @@ import "package:separate/separate.dart";
 
 import "../../../../../config/ui_config.dart";
 import "../../../../../theme/app_theme.dart";
+import "../../../../../utils/context_extensions.dart";
 import "../../../../../widgets/my_expansion_tile.dart";
 import "../../data/models/sks_menu_data.dart";
 
@@ -40,7 +41,7 @@ class SksMenuDishDetailsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasIncreasedTextSize = MediaQuery.textScalerOf(context).scale(1) > 1;
+    final hasIncreasedTextSize = context.isTextScaledUp;
     return DecoratedBox(
       decoration: BoxDecoration(
         color: context.colorTheme.whiteSoap,

--- a/lib/hooks/use_semantics_service_on_changed_value.dart
+++ b/lib/hooks/use_semantics_service_on_changed_value.dart
@@ -1,0 +1,17 @@
+import "package:flutter/semantics.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+
+void useSemanticsServiceOnChangedValue<T>(T value, {required String Function(T value) messageBuilder}) {
+  final isFirstRender = useRef(true);
+
+  useEffect(() {
+    if (isFirstRender.value) {
+      isFirstRender.value = false;
+      return null;
+    }
+    Future.microtask(() async {
+      await SemanticsService.announce(messageBuilder(value), TextDirection.ltr);
+    });
+    return null;
+  }, [value]);
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -527,5 +527,19 @@
   "axis_vertical_screen_reader": "vertical axis",
   "sks_chart_average_21_days_screen_reader_label": "Average number of people over the last 21 days at the current hour:",
   "sks_chart_max_today_screen_reader_label": "Maximum number of people today:",
-  "sks_chart_max_21_days_screen_reader_label": "Maximum number of people over the last 21 days:"
+  "sks_chart_max_21_days_screen_reader_label": "Maximum number of people over the last 21 days:",
+  "clear_search": "Clear search",
+  "my_location_button_tooltip": "My location",
+  "map_view_description": "Map view with buildings markers. You have bottom sheet with a list of buildings. Scroll up to expand it.",
+  "bottom_scroll_sheet_description_collapsed": "Bottom scroll sheet. Scroll down to collapse it.",
+  "bottom_scroll_sheet_description_expanded": "Bottom scroll sheet. Scroll up to collapse it.",
+  "building_tile_selected": "Selected",
+  "building_tile_building": "Building",
+  "building_tile_address": "Address",
+  "building_tile_digital_guide_available": "Digital guide available",
+  "internal_link": "Internal application link",
+  "external_link": "External link leading to {url}",
+  "building_tile_unselected": "Unselected",
+  "expanded_screen_reader_label": "Expanded",
+  "collapsed_screen_reader_label": "Collapsed"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3070,11 +3070,11 @@
     "description": "information about some logotype"
   },
   "notifications": "Powiadomienia",
-  "@notifications":{
+  "@notifications": {
     "description": "information about notifications"
   },
   "feedback_option_not_supported_for_screen_readers": "Ta opcja nie jest wspierana dla czytników ekranów. Jeśli chcesz zgłosić błąd lub sugestię napisz do nas wiadomość e-mail.",
-  "@feedback_option_not_supported_for_screen_readers":{
+  "@feedback_option_not_supported_for_screen_readers": {
     "description": "information about feedback option that's not supported for screen readers"
   },
   "incoming_days_changes_days": "{days, plural, =1{1 dzień}  other{{days} dni}}",
@@ -3230,5 +3230,67 @@
   "sks_chart_max_21_days_screen_reader_label": "Maksymalna wartość średniej kroczącej liczby osób w ciągu ostatnich 21 dni wynosi",
   "@sks_chart_max_21_days_screen_reader_label": {
     "description": "Text read for sks chart max 21 days"
+  },
+  "clear_search": "Wyczyść wyszukiwanie",
+  "@clear_search": {
+    "description": "Text read for clear search button"
+  },
+  "my_location_button_tooltip": "Moje położenie",
+  "@my_location_button_tooltip": {
+    "description": "Text read for my location button"
+  },
+  "map_view_description": "Widok mapy ze znacznikami budynków. U dołu znajduje się lista budynków. Przewiń w górę, aby ją rozwinąć.",
+  "@map_view_description": {
+    "description": "Text read for map view description"
+  },
+  "bottom_scroll_sheet_description_collapsed": "Szuflada dolna z listą. Przewiń w górę, aby ją rozwinąć.",
+  "@bottom_scroll_sheet_description_collapsed": {
+    "description": "Text read for bottom scroll sheet description when it's collapsed"
+  },
+  "bottom_scroll_sheet_description_expanded": "Szuflada dolna z listą. Przewiń w dół, aby ją zwinąć.",
+  "@bottom_scroll_sheet_description_expanded": {
+    "description": "Text read for bottom scroll sheet description when it's expanded"
+  },
+  "building_tile_selected": "Wybrano",
+  "@building_tile_selected": {
+    "description": "Text read for building tile selected"
+  },
+  "building_tile_unselected": "Odznaczono",
+  "@building_tile_unselected": {
+    "description": "Text read for building tile unselected"
+  },
+  "building_tile_building": "Budynek",
+  "@building_tile_building": {
+    "description": "Text read for building tile building"
+  },
+  "building_tile_address": "Adres",
+  "@building_tile_address": {
+    "description": "Text read for building tile address"
+  },
+  "building_tile_digital_guide_available": "Dostępny cyfrowy przewodnik",
+  "@building_tile_digital_guide_available": {
+    "description": "Text read for building tile digital guide available"
+  },
+  "internal_link": "Odnośnik wewnętrzny aplikacji",
+  "@internal_link": {
+    "description": "Tooltip text for internal application links"
+  },
+  "external_link": "Odnośnik zewnętrzny prowadzący do {url}",
+  "@external_link": {
+    "description": "Tooltip text for external links",
+    "placeholders": {
+      "url": {
+        "type": "String",
+        "example": "https://example.com"
+      }
+    }
+  },
+  "expanded_screen_reader_label": "Rozwinięto",
+  "@expanded_screen_reader_label": {
+    "description": "Action read for expanded"
+  },
+  "collapsed_screen_reader_label": "Zwinięto",
+  "@collapsed_screen_reader_label": {
+    "description": "Action read for collapsed"
   }
 }

--- a/lib/utils/context_extensions.dart
+++ b/lib/utils/context_extensions.dart
@@ -16,4 +16,12 @@ extension BuildContextX on BuildContext {
   void unfocus() {
     FocusScope.of(this).unfocus();
   }
+
+  TextScaler get textScaler => MediaQuery.textScalerOf(this);
+
+  double get textScaleFactor => textScaler.scale(1);
+
+  bool get isTextScaledUp => textScaleFactor > 1;
+
+  bool get isTextScaledDown => textScaleFactor < 1;
 }

--- a/lib/widgets/dual_text_max_lines.dart
+++ b/lib/widgets/dual_text_max_lines.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../features/science_club/science_clubs_view/widgets/strategic_badge.dart";
 import "../features/science_club/science_clubs_view/widgets/verified_badge.dart";
+import "../utils/context_extensions.dart";
 
 class DualTextSpan extends TextSpan {
   DualTextSpan(
@@ -54,10 +55,11 @@ class DualTextMaxLines extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return RichText(
+    return Text.rich(
+      textScaler: context.textScaler.clamp(maxScaleFactor: 2),
       maxLines: maxTotalLines,
       overflow: TextOverflow.ellipsis,
-      text: DualTextSpan(
+      DualTextSpan(
         title,
         titleStyle,
         subtitle,

--- a/lib/widgets/search_box.dart
+++ b/lib/widgets/search_box.dart
@@ -45,8 +45,8 @@ class SearchBox extends HookWidget {
       onTapOutside: onTapOutside,
       onChanged: onChanged,
       decoration: InputDecoration(
-        constraints: const BoxConstraints(maxHeight: SearchBoxConfig.height),
-        contentPadding: EdgeInsets.zero,
+        constraints: BoxConstraints(maxHeight: context.textScaler.scale(SearchBoxConfig.height)),
+        contentPadding: context.isTextScaledUp ? const EdgeInsets.symmetric(vertical: 4) : EdgeInsets.zero,
         filled: true,
         fillColor: context.colorTheme.greyLight,
         hintText: "${searchText ?? context.localize.search}...",
@@ -59,7 +59,7 @@ class SearchBox extends HookWidget {
             showCloseIcon.value
                 ? IconButton(
                   tooltip: context.localize.clear_search,
-                  icon: Icon(Icons.cancel, color: context.colorTheme.blackMirage, size: 19),
+                  icon: Icon(Icons.cancel, color: context.colorTheme.blackMirage, size: context.textScaler.scale(19)),
                   onPressed: onSuffixPressed,
                 )
                 : null,

--- a/lib/widgets/search_box.dart
+++ b/lib/widgets/search_box.dart
@@ -52,13 +52,13 @@ class SearchBox extends HookWidget {
         hintText: "${searchText ?? context.localize.search}...",
         hintStyle: context.textTheme.lightTitle.copyWith(color: color),
         border: OutlineInputBorder(borderRadius: BorderRadius.circular(8), borderSide: BorderSide.none),
-        prefixIcon: Padding(
-          padding: const EdgeInsets.all(10),
-          child: SvgPicture.asset(Assets.svg.searchBox.vectorsearch),
+        prefixIcon: ExcludeSemantics(
+          child: Padding(padding: const EdgeInsets.all(10), child: SvgPicture.asset(Assets.svg.searchBox.vectorsearch)),
         ),
         suffixIcon:
             showCloseIcon.value
                 ? IconButton(
+                  tooltip: context.localize.clear_search,
                   icon: Icon(Icons.cancel, color: context.colorTheme.blackMirage, size: 19),
                   onPressed: onSuffixPressed,
                 )

--- a/lib/widgets/search_box_app_bar.dart
+++ b/lib/widgets/search_box_app_bar.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 
 import "../config/ui_config.dart";
 import "../theme/app_theme.dart";
+import "../utils/context_extensions.dart";
 import "detail_views/pop_button.dart";
 import "search_box.dart";
 
@@ -20,7 +21,7 @@ class SearchBoxAppBar extends AppBar {
     bool addLeadingPopButton = false,
     super.primary = false,
   }) : super(
-         title: Text(title),
+         title: Text(title, textScaler: context.textScaler.clamp(maxScaleFactor: 2.5)),
          titleTextStyle: context.textTheme.headline,
          backgroundColor: context.colorTheme.whiteSoap,
          scrolledUnderElevation: 0,
@@ -36,7 +37,9 @@ class SearchBoxAppBar extends AppBar {
                  : null,
          leadingWidth: addLeadingPopButton ? 80 : 0,
          bottom: PreferredSize(
-           preferredSize: Size.fromHeight(SearchBoxConfig.height + bottomPadding),
+           preferredSize: Size.fromHeight(
+             context.textScaler.clamp(maxScaleFactor: 2.5).scale(SearchBoxConfig.height) + bottomPadding,
+           ),
            child: Padding(
              padding: EdgeInsets.only(
                bottom: bottomPadding,

--- a/lib/widgets/text_and_url_widget.dart
+++ b/lib/widgets/text_and_url_widget.dart
@@ -3,6 +3,7 @@ import "package:flutter/gestures.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../theme/app_theme.dart";
+import "../utils/context_extensions.dart";
 import "../utils/launch_url_util.dart";
 
 class TextAndUrl extends ConsumerWidget {
@@ -33,7 +34,7 @@ class TextAndUrl extends ConsumerWidget {
         ),
         textAlign: TextAlign.center,
         style: context.textTheme.body,
-        textScaler: !scaleText ? MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 1) : null,
+        textScaler: !scaleText ? context.textScaler.clamp(maxScaleFactor: 1) : null,
       ),
     );
   }

--- a/lib/widgets/wide_tile_card.dart
+++ b/lib/widgets/wide_tile_card.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart";
 import "../config/ui_config.dart";
 import "../features/science_club/science_clubs_view/widgets/ensure_visible_tags.dart";
 import "../theme/app_theme.dart";
+import "../utils/context_extensions.dart";
 import "optimized_directus_image.dart";
 
 class PhotoTrailingWideTileCard extends WideTileCard {
@@ -15,6 +16,7 @@ class PhotoTrailingWideTileCard extends WideTileCard {
     super.activeGradient,
     super.activeShadows,
     super.key,
+    super.crossAxisAlignment,
     BoxFit boxFit = BoxFit.cover,
   }) : super(
          trailing: SizedBox.square(
@@ -68,21 +70,25 @@ class WideTileCard extends StatelessWidget {
               borderRadius: const BorderRadius.all(WideTileCardConfig.radius),
               boxShadow: isActive ? activeShadows : null,
             ),
-            child: Row(
-              crossAxisAlignment: crossAxisAlignment,
-              children: [
-                Expanded(
-                  child: _TitlesColumn(
-                    title,
-                    subtitle,
-                    secondSubtitle,
-                    showBadge: showBadge,
-                    showStrategicBadge: showStrategicBadge,
-                    isActive: isActive,
+            child: SizedBox(
+              height: context.textScaler.clamp(maxScaleFactor: 2).scale(WideTileCardConfig.imageSize),
+              child: Row(
+                crossAxisAlignment: crossAxisAlignment,
+                children: [
+                  Expanded(
+                    child: _TitlesColumn(
+                      title,
+                      subtitle,
+                      secondSubtitle,
+                      showBadge: showBadge,
+                      showStrategicBadge: showStrategicBadge,
+                      isActive: isActive,
+                    ),
                   ),
-                ),
-                if (trailing != null) trailing!,
-              ],
+                  const SizedBox(width: 16),
+                  if (trailing != null) trailing!,
+                ],
+              ),
             ),
           ),
         ),
@@ -112,7 +118,6 @@ class _TitlesColumn extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         const basePadding = WideTileCardConfig.basePadding;
-
         return Padding(
           padding: const EdgeInsets.only(left: basePadding, top: basePadding, right: basePadding),
           child: EnsureVisibleTags(
@@ -123,7 +128,7 @@ class _TitlesColumn extends StatelessWidget {
             spacing: secondSubtitle == null ? WideTileCardConfig.titlesSpacing : 2,
             secondSubtitle: secondSubtitle,
             secondSubtitleStyle: isActive ? context.textTheme.bodyWhite : context.textTheme.bodyBlue,
-            maxTotalLines: 4,
+            maxTotalLines: context.textScaleFactor > 1.5 ? 5 : 4,
             showVerifiedBadge: showBadge,
             showStrategicBadge: showStrategicBadge,
           ),


### PR DESCRIPTION
1. added few custom screen reader things
2. the font scaling was pain in the ass, but I've more or less adjusted it 

 
![image](https://github.com/user-attachments/assets/0d5e934e-8555-4461-9363-befa1e52e1a9)
![image](https://github.com/user-attachments/assets/54380b00-ed79-4649-906d-056e2f197413)
![image](https://github.com/user-attachments/assets/043aa9e0-5970-4a45-82ec-6faa632e6a7e)
![image](https://github.com/user-attachments/assets/d9d30926-f218-4af4-8649-dc2607ac8eb7)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance accessibility for building screen list with screen reader support and font scaling adjustments across multiple components.
> 
>   - **Accessibility Enhancements**:
>     - Introduced `useSemanticsServiceOnChangedValue` hook in `use_semantics_service_on_changed_value.dart` for announcing changes in UI state to screen readers.
>     - Added semantic labels and descriptions for screen readers in `bottom_scroll_sheet.dart`, `building_tile.dart`, and `map_widget.dart`.
>     - Updated `app_en.arb` and `app_pl.arb` with new localization strings for accessibility features.
>   - **Font Scaling Adjustments**:
>     - Implemented text scaling constraints using `context.textScaler` in `context_extensions.dart`.
>     - Applied text scaling in `navigate_button.dart`, `science_clubs_info_dialog.dart`, and `sks_chart_header.dart`.
>   - **UI Components**:
>     - Modified `WideTileCard` and `DualTextMaxLines` to support dynamic text scaling and semantic enhancements.
>     - Updated `SearchBox` and `SearchBoxAppBar` to handle text scaling and accessibility improvements.
>   - **Miscellaneous**:
>     - Adjusted icon sizes and tooltips in `my_loc_button.dart` and `general_offline_message.dart` for better accessibility.
>     - Added strategic and verified badges with scaling in `strategic_badge.dart` and `verified_badge.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 0dec632255dac9f2f095b025ea02b291a0178130. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->