### PR TITLE
fix(navigation): translate bottom nav bar labels

### DIFF
--- a/lib/config/nav_bar_config.dart
+++ b/lib/config/nav_bar_config.dart
@@ -7,17 +7,26 @@ import "../features/parkings/parkings_view/widgets/parkings_icons.icons.dart";
 import "../utils/context_extensions.dart";
 
 enum NavBarEnum {
-  home(BottomNavBarIcons.home_icon, 26, "Home"),
-  buildings(BottomNavBarIcons.map_icon, 20, "Map"),
-  parkings(ParkingsIcons.directions_car, 19, "Parkings"),
-  guide(BottomNavBarIcons.info_icon, 22, "Guide"),
-  navigation(BottomNavBarIcons.view_grid, 26, "Navigation Tab");
+  home(BottomNavBarIcons.home_icon, 26),
+  buildings(BottomNavBarIcons.map_icon, 20),
+  parkings(ParkingsIcons.directions_car, 19),
+  guide(BottomNavBarIcons.info_icon, 22),
+  navigation(BottomNavBarIcons.view_grid, 26);
 
-  const NavBarEnum(this.icon, this.size, this.label);
+  const NavBarEnum(this.icon, this.size);
 
   final IconData icon;
   final double size;
-  final String label;
+
+  String getLabel(BuildContext context) {
+    return switch (this) {
+      NavBarEnum.home => context.localize.nav_home,
+      NavBarEnum.buildings => context.localize.nav_map,
+      NavBarEnum.parkings => context.localize.nav_parkings,
+      NavBarEnum.guide => context.localize.nav_guide,
+      NavBarEnum.navigation => context.localize.nav_others,
+    };
+  }
 }
 
 abstract class NavBarConfig {

--- a/lib/features/bottom_nav_bar/bottom_nav_bar.dart
+++ b/lib/features/bottom_nav_bar/bottom_nav_bar.dart
@@ -49,7 +49,7 @@ class _NavigationBarItemsList extends DelegatingList<BottomNavigationBarItem> {
                           : context.colorTheme.blackMirage.withValues(alpha: .16),
                   size: e.size,
                 ),
-                label: e.label,
+                label: e.getLabel(context),
               ),
             )
             .toList(),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -559,5 +559,10 @@
   "toilet": "Toilet",
   "audio_message_comment_screen_reader": "To play the message, click the play button.",
   "audio_player_slider": "Playback slider. {value} percent.",
-  "go_to_section": "Go to {action} of {title}"
+  "go_to_section": "Go to {action} of {title}",
+  "nav_home": "Home",
+  "nav_map": "Map",
+  "nav_parkings": "Parkings",
+  "nav_guide": "Guide",
+  "nav_others": "Others"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3396,5 +3396,25 @@
         "example": "Budynki"
       }
     }
+  },
+  "nav_home": "Strona główna",
+  "@nav_home": {
+    "description": "Label for home navigation item"
+  },
+  "nav_map": "Mapa",
+  "@nav_map": {
+    "description": "Label for map navigation item"
+  },
+  "nav_parkings": "Parkingi",
+  "@nav_parkings": {
+    "description": "Label for parkings navigation item"
+  },
+  "nav_guide": "Przewodnik",
+  "@nav_guide": {
+    "description": "Label for guide navigation item"
+  },
+  "nav_others": "Inne",
+  "@nav_others": {
+    "description": "Label for others navigation item"
   }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Translate bottom navigation bar labels using localization files, updating `NavBarEnum` and `BottomNavigationBarItem` to fetch localized labels.
> 
>   - **Behavior**:
>     - `NavBarEnum` in `nav_bar_config.dart` now uses `getLabel(context)` to fetch localized labels instead of hardcoded strings.
>     - `BottomNavigationBarItem` in `bottom_nav_bar.dart` updated to use `e.getLabel(context)` for labels.
>   - **Localization**:
>     - Added `nav_home`, `nav_map`, `nav_parkings`, `nav_guide`, `nav_others` to `app_en.arb` and `app_pl.arb` for navigation labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for cf1fdac99233b5a9ccfaae2c8aff80b09fb6ce80. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->