### PR TITLE
fix(parkings): fix parkings tile bug

### DIFF
--- a/lib/features/parkings/parkings_view/widgets/parking_wide_tile_card.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_wide_tile_card.dart
@@ -94,11 +94,13 @@ class _LeftColumn extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           if (!isActive)
-            Padding(
-              padding: ParkingsConfig.extraIndentPadd,
-              child: Semantics(
-                label: context.localize.parking_opening_hours_reader_label,
-                child: Flexible(child: Text(parking.openingHours, style: context.iParkingTheme.small)),
+            Flexible(
+              child: Padding(
+                padding: ParkingsConfig.extraIndentPadd,
+                child: Semantics(
+                  label: context.localize.parking_opening_hours_reader_label,
+                  child: Text(parking.openingHours, style: context.iParkingTheme.small),
+                ),
               ),
             ),
           if (isActive) Expanded(child: Center(child: ParkingChart(parking))),


### PR DESCRIPTION
I didn't have the grey rectangle that was shown in the task description photo, so the screen looked like shown below. But I found what causes the "Incorrect use of ParentDataWidget" and i hope this is a fix for the problem.
![Screenshot_1751142403](https://github.com/user-attachments/assets/f2c05577-64c6-4035-bc09-dca63757f36a)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes "Incorrect use of ParentDataWidget" error in `parking_wide_tile_card.dart` by wrapping `Padding` with `Flexible`.
> 
>   - **Bug Fix**:
>     - Fixes "Incorrect use of ParentDataWidget" error in `_LeftColumn` in `parking_wide_tile_card.dart` by wrapping `Padding` with `Flexible` when `isActive` is false.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 62b1c45dacf96556e9caa189942130fee63497c7. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->