### PR TITLE
fix/add field of studies enum type

### DIFF
--- a/lib/features/departments/department_detail_view/data/models/department_details.dart
+++ b/lib/features/departments/department_detail_view/data/models/department_details.dart
@@ -2,8 +2,8 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/foundation.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:solvro_translator_core/solvro_translator_core.dart";
-
 import "../../../../../api_base_rest/shared_models/social_links_data.dart";
+import "./studies_type.dart";
 
 part "department_details.freezed.dart";
 part "department_details.g.dart";
@@ -42,9 +42,8 @@ abstract class FieldOfStudy with _$FieldOfStudy {
   const factory FieldOfStudy({
     required String name,
     required String url,
-    required int semesterCount, // TODO(simon-the-shark): fix to new schema, #759
     required bool isEnglish,
-    required bool is2ndDegree,
+    required StudiesType studiesType,
     required bool hasWeekendOption,
   }) = _FieldOfStudy;
 

--- a/lib/features/departments/department_detail_view/data/models/studies_type.dart
+++ b/lib/features/departments/department_detail_view/data/models/studies_type.dart
@@ -1,0 +1,21 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "studies_type.g.dart";
+
+@JsonEnum(fieldRename: FieldRename.snake, alwaysCreate: true)
+enum StudiesType {
+  @JsonValue("1DEGREE")
+  firstDegree,
+
+  @JsonValue("2DEGREE")
+  secondDegree,
+
+  @JsonValue("LONG_CYCLE")
+  longCycle,
+}
+
+extension StudiesTypeX on StudiesType {
+  bool get isFirstDegree => this == StudiesType.firstDegree;
+  bool get isSecondDegree => this == StudiesType.secondDegree;
+  bool get isLongCycle => this == StudiesType.longCycle;
+}

--- a/lib/features/departments/department_detail_view/data/utils/department_details_extension.dart
+++ b/lib/features/departments/department_detail_view/data/utils/department_details_extension.dart
@@ -5,6 +5,7 @@ import "../../../../../config/env.dart";
 import "../../../../../theme/hex_color.dart";
 import "../../../../../utils/colors_sort.dart";
 import "../models/department_details.dart";
+import "../models/studies_type.dart";
 
 extension DetailedDepartmentsX on DepartmentDetails {
   LinearGradient get gradient =>
@@ -19,22 +20,16 @@ extension DetailedDepartmentsX on DepartmentDetails {
   }
 }
 
-extension CycleStudiesFormatterX on FieldOfStudy {
-  bool get isLongCycleStudies {
-    return semesterCount >= 12;
-  }
-}
-
 extension WhereTypesX on IList<FieldOfStudy> {
   Iterable<FieldOfStudy> get whereFirstDegree {
-    return where((item) => !item.is2ndDegree && !item.isLongCycleStudies);
+    return where((item) => !item.studiesType.isSecondDegree && !item.studiesType.isLongCycle);
   }
 
   Iterable<FieldOfStudy> get whereSecondDegree {
-    return where((item) => item.is2ndDegree && !item.isLongCycleStudies);
+    return where((item) => item.studiesType.isSecondDegree && !item.studiesType.isLongCycle);
   }
 
   Iterable<FieldOfStudy> get whereLongCycle {
-    return where((item) => item.isLongCycleStudies);
+    return where((item) => item.studiesType.isLongCycle);
   }
 }


### PR DESCRIPTION
I fixed logic to new schema
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduce `StudiesType` enum to replace degree logic in `FieldOfStudy` and update related extensions.
> 
>   - **Models**:
>     - Add `StudiesType` enum in `studies_type.dart` with values `firstDegree`, `secondDegree`, and `longCycle`.
>     - Replace `is2ndDegree` and `isLongCycleStudies` with `studiesType` in `FieldOfStudy` in `department_details.dart`.
>     - Remove `semesterCount` from `FieldOfStudy` in `department_details.dart`.
>   - **Extensions**:
>     - Update `WhereTypesX` in `department_details_extension.dart` to use `studiesType` for filtering `FieldOfStudy`.
>     - Remove `CycleStudiesFormatterX` extension in `department_details_extension.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 91974bcc11c97a48047bd8e68a296349e3d4a4d2. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->