### PR TITLE
fix: add unwaited microtask util

### DIFF
--- a/lib/api_base/cache/remote_flush/presentation/flush_cache_remotely_widget.dart
+++ b/lib/api_base/cache/remote_flush/presentation/flush_cache_remotely_widget.dart
@@ -1,9 +1,8 @@
-import "dart:async";
-
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 
 import "../../../../hooks/use_effect_on_init.dart";
+import "../../../../utils/unwaited_microtask.dart";
 import "../business/flush_cache_use_cases.dart";
 
 class FlushCacheRemotelyWidget extends HookConsumerWidget {
@@ -13,7 +12,7 @@ class FlushCacheRemotelyWidget extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffectOnInit(() {
-      unawaited(Future.microtask(ref.flushAllCacheIfNeeded));
+      unwaitedMicrotask(ref.flushAllCacheIfNeeded);
       return null;
     });
     return child;

--- a/lib/features/app_changelog/update_changelog_wrapper.dart
+++ b/lib/features/app_changelog/update_changelog_wrapper.dart
@@ -3,6 +3,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 
 import "../../hooks/use_effect_on_init.dart";
 import "../../services/translations_service/data/preferred_lang_repository.dart";
+import "../../utils/unwaited_microtask.dart";
 import "../settings/widgets/language_settings_dialog.dart";
 import "show_changelog.dart";
 
@@ -14,7 +15,7 @@ class UpdateChangelogWrapper extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffectOnInit(() {
-      Future.microtask(() async {
+      unwaitedMicrotask(() async {
         if (context.mounted) {
           final preferredLanguage = await ref.read(preferredLanguageRepositoryProvider.future);
           if (preferredLanguage == null && context.mounted) {

--- a/lib/features/bottom_scroll_sheet/hooks/use_initial_active_id.dart
+++ b/lib/features/bottom_scroll_sheet/hooks/use_initial_active_id.dart
@@ -3,6 +3,7 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 
+import "../../../utils/unwaited_microtask.dart";
 import "../../map_view/controllers/active_map_marker_cntrl.dart";
 import "../../map_view/controllers/controllers_set.dart";
 
@@ -17,7 +18,7 @@ void useInitialActiveId<T extends GoogleNavigable>(
   useEffect(() {
     final activeItem = items.firstWhereOrNull((item) => item.id == initialActiveId);
     if (activeItem != null) {
-      Future.microtask(() => activeMarkerController.selectItem(activeItem));
+      unwaitedMicrotask(() async => activeMarkerController.selectItem(activeItem));
       Future.delayed(Durations.short1, () => zoomOnMarker(activeItem));
     }
     return null;

--- a/lib/features/map_view/controllers/bottom_sheet_controller.dart
+++ b/lib/features/map_view/controllers/bottom_sheet_controller.dart
@@ -2,6 +2,8 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
+import "../../../utils/unwaited_microtask.dart";
+
 part "bottom_sheet_controller.g.dart";
 
 @Riverpod(dependencies: [])
@@ -28,7 +30,7 @@ class BottomSheetPixels extends _$BottomSheetPixels {
   }
 
   void _update() {
-    Future.microtask(() => state = ref.read(bottomSheetControllerProvider).pixelsSafe);
+    unwaitedMicrotask(() async => state = ref.read(bottomSheetControllerProvider).pixelsSafe);
   }
 
   Future<void> onSearchBoxTap() async {

--- a/lib/features/navigator/navigation_stack.dart
+++ b/lib/features/navigator/navigation_stack.dart
@@ -3,6 +3,8 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
+import "../../utils/unwaited_microtask.dart";
+
 part "navigation_stack.g.dart";
 
 @Riverpod(keepAlive: true)
@@ -66,7 +68,7 @@ class NavigationObserver extends NavigatorObserver {
   This 2 methods sync observer with the riverpod state
   */
   void setStack(IList<Route<dynamic>> value) {
-    Future.microtask(() => ref.read(navigationStackProvider.notifier).setStack(value));
+    unwaitedMicrotask(() async => ref.read(navigationStackProvider.notifier).setStack(value));
   }
 
   IList<Route<dynamic>> get stack => ref.read(navigationStackProvider);

--- a/lib/features/science_club/science_clubs_filters/hooks/use_initial_filter_ids.dart
+++ b/lib/features/science_club/science_clubs_filters/hooks/use_initial_filter_ids.dart
@@ -1,6 +1,7 @@
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 
+import "../../../../utils/unwaited_microtask.dart";
 import "../filters_controller.dart";
 
 // use this hook to load initial set of filters when the widget is first built
@@ -12,7 +13,7 @@ void useInitialFilterIds<T>(
 ) {
   if (ids == null) return;
   useEffect(() {
-    Future.microtask(() async {
+    unwaitedMicrotask(() async {
       final items = await itemsCallback();
       filterController.clearFilter();
       items.where((item) => test(ids, item)).forEach(filterController.toggleFilter);

--- a/lib/hooks/use_semantics_service_on_changed_value.dart
+++ b/lib/hooks/use_semantics_service_on_changed_value.dart
@@ -1,6 +1,8 @@
 import "package:flutter/semantics.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
 
+import "../utils/unwaited_microtask.dart";
+
 void useSemanticsServiceOnChangedValue<T>(T value, {required String? Function(T value) messageBuilder}) {
   final isFirstRender = useRef(true);
 
@@ -9,7 +11,7 @@ void useSemanticsServiceOnChangedValue<T>(T value, {required String? Function(T 
       isFirstRender.value = false;
       return null;
     }
-    Future.microtask(() async {
+    unwaitedMicrotask(() async {
       final message = messageBuilder(value);
       if (message != null) {
         await SemanticsService.announce(message, TextDirection.ltr);

--- a/lib/services/translations_service/widgets/remove_old_translations.dart
+++ b/lib/services/translations_service/widgets/remove_old_translations.dart
@@ -1,9 +1,8 @@
-import "dart:async";
-
 import "package:flutter/widgets.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 
 import "../../../hooks/use_effect_on_init.dart";
+import "../../../utils/unwaited_microtask.dart";
 import "../business/flush_cache_drift_use_cases.dart";
 
 class RemoveOldTranslations extends HookConsumerWidget {
@@ -14,7 +13,7 @@ class RemoveOldTranslations extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     useEffectOnInit(() {
-      unawaited(Future.microtask(ref.flushOldData));
+      unwaitedMicrotask(ref.flushOldData);
       return null;
     });
     return child;

--- a/lib/utils/unwaited_microtask.dart
+++ b/lib/utils/unwaited_microtask.dart
@@ -1,0 +1,7 @@
+import "dart:async";
+
+/// Schedules a microtask to run asynchronously without waiting for its completion.
+/// This is useful when you want to fire-and-forget an async operation.
+void unwaitedMicrotask<T>(Future<T> Function() microtask) {
+  unawaited(Future.microtask(microtask));
+}

--- a/lib/widgets/my_error_widget.dart
+++ b/lib/widgets/my_error_widget.dart
@@ -14,6 +14,7 @@ import "../features/parkings/parkings_view/widgets/offline_parkings_view.dart";
 import "../gen/assets.gen.dart";
 import "../theme/app_theme.dart";
 import "../utils/context_extensions.dart";
+import "../utils/unwaited_microtask.dart";
 
 class MyErrorWidget extends HookWidget {
   const MyErrorWidget(this.error, {required this.stackTrace, super.key});
@@ -26,7 +27,7 @@ class MyErrorWidget extends HookWidget {
     useEffect(() {
       if (error != null) {
         Logger().e(error.toString(), stackTrace: stackTrace);
-        Future.microtask(() async => Sentry.captureException(error, stackTrace: stackTrace));
+        unwaitedMicrotask(() async => Sentry.captureException(error, stackTrace: stackTrace));
       }
       return null;
     }, [error, stackTrace]);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `unwaitedMicrotask` utility for fire-and-forget operations and refactor existing code to use it.
> 
>   - **Utility Function**:
>     - Adds `unwaitedMicrotask` in `unwaited_microtask.dart` to schedule microtasks without awaiting their completion.
>   - **Refactoring**:
>     - Replaces `Future.microtask` with `unwaitedMicrotask` in `FlushCacheRemotelyWidget`, `UpdateChangelogWrapper`, `useInitialActiveId`, `BottomSheetPixels`, `NavigationObserver`, `useInitialFilterIds`, `useSemanticsServiceOnChangedValue`, `RemoveOldTranslations`, and `MyErrorWidget`.
>   - **Imports**:
>     - Adds import for `unwaited_microtask.dart` in affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 3f88c45b0f07d67638669d8fd12f76ba4e78bb41. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->