### PR TITLE
feat(news): add read more button

### DIFF
--- a/lib/config/url_config.dart
+++ b/lib/config/url_config.dart
@@ -2,4 +2,7 @@ abstract class UrlConfig {
   static const academicCalendarUrl = "https://pwr.edu.pl/studenci/kalendarz-akademicki";
 
   static const topwrUrl = "https://topwr.solvro.pl/";
+
+  static const newsfeedUrlPL = "https://pwr.edu.pl/uczelnia/aktualnosci";
+  static const newsfeedUrlENG = "https://pwr.edu.pl/en/university/news";
 }

--- a/lib/features/newsfeed/presentation/news_list_view.dart
+++ b/lib/features/newsfeed/presentation/news_list_view.dart
@@ -2,12 +2,16 @@ import "package:auto_route/auto_route.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:solvro_translator_core/solvro_translator_core.dart";
 
 import "../../../../widgets/my_error_widget.dart";
 import "../../../config/ui_config.dart";
+import "../../../config/url_config.dart";
+import "../../../services/translations_service/data/preferred_lang_repository.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../utils/launch_url_util.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../widgets/my_text_button.dart";
 import "../../../widgets/wide_tile_card.dart";
 import "../../departments/departments_view/widgets/departments_view_loading.dart";
 import "../../guide_view/widgets/guide_grid.dart";
@@ -40,7 +44,25 @@ class _NewsfeedViewContent extends ConsumerWidget {
 
     return switch (newsfeed) {
       AsyncError(:final error, :final stackTrace) => MyErrorWidget(error, stackTrace: stackTrace),
-      AsyncValue(:final IList<Article> value) => GuideGrid(children: [for (final item in value) NewsTile(item)].lock),
+      AsyncValue(:final IList<Article> value) => GuideGrid(
+        children: [
+          for (final item in value) NewsTile(item),
+          Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: double.infinity,
+              child: MyTextButton(
+                actionTitle: context.localize.read_more_arrows,
+                onClick: () => ref.launch(
+                  ref.watch(preferredLanguageRepositoryProvider).valueOrNull != SolvroLocale.pl
+                      ? UrlConfig.newsfeedUrlENG
+                      : UrlConfig.newsfeedUrlPL,
+                ),
+              ),
+            ),
+          ),
+        ].lock,
+      ),
       _ => const Padding(padding: GuideViewConfig.gridPadding, child: DepartmentsViewLoading()),
     };
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -38,6 +38,7 @@
   "follow_solvro": "Follow us on social media!",
   "unknown_day": "on this beautiful day!",
   "read_more": "Read more",
+  "read_more_arrows": "Read more >>",
   "whats_up": "What's up?",
   "study_circles": "Student organizations",
   "day": "day",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -149,6 +149,10 @@
   "@read_more": {
     "description": "Button text to expand content"
   },
+  "read_more_arrows": "Czytaj więcej >>",
+  "@read_more_arrows": {
+    "description": "Button text to expand content with arrows"
+  },
   "whats_up": "Co słychać?",
   "@whats_up": {
     "description": "Casual greeting text"


### PR DESCRIPTION
closes #846 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'Read More' button to newsfeed view with language-specific URLs and localization support.
> 
>   - **UI Changes**:
>     - Add `MyTextButton` in `news_list_view.dart` to display a 'Read More' button at the end of the news list.
>     - Button launches URL based on preferred language: `UrlConfig.newsfeedUrlENG` or `UrlConfig.newsfeedUrlPL`.
>   - **Localization**:
>     - Add `read_more_arrows` string in `app_en.arb` and `app_pl.arb` for button text with arrows.
>   - **Configuration**:
>     - Add `newsfeedUrlPL` and `newsfeedUrlENG` to `UrlConfig` in `url_config.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for d4c467ed6609cd4a6f5edecdd5b6d9ea981f8c3b. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->