### PR TITLE
fix(sci-clubs): align statuses with backend

### DIFF
--- a/lib/features/science_club/science_clubs_view/model/science_clubs.dart
+++ b/lib/features/science_club/science_clubs_view/model/science_clubs.dart
@@ -13,7 +13,7 @@ part "science_clubs.g.dart";
 part "science_clubs.translatable.g.dart";
 
 @JsonEnum(fieldRename: FieldRename.snake)
-enum ScienceClubStatus { active, archived, unknown }
+enum ScienceClubStatus { active, inactive, dissolved, unknown }
 
 @JsonEnum(fieldRename: FieldRename.snake)
 enum ScienceClubSource {

--- a/lib/features/science_club/science_clubs_view/repository/science_clubs_repository.dart
+++ b/lib/features/science_club/science_clubs_view/repository/science_clubs_repository.dart
@@ -33,7 +33,7 @@ Future<IList<ScienceClub>> scienceClubsRepository(Ref ref) async {
   return response.data
       .whereType<ScienceClub>()
       .map((club) => club)
-      .where((club) => club.organizationStatus != ScienceClubStatus.archived)
+      .where((club) => club.organizationStatus == ScienceClubStatus.active)
       .sortBySourceTypes()
       .sortByBranch(branch)
       .toIList();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ScienceClubStatus` enum and repository filtering logic to align with backend changes, replacing `archived` with `inactive` and `dissolved`.
> 
>   - **Enums**:
>     - Update `ScienceClubStatus` in `science_clubs.dart` to include `inactive` and `dissolved`, replacing `archived`.
>   - **Repository**:
>     - Modify `scienceClubsRepository` in `science_clubs_repository.dart` to filter clubs with `organizationStatus == ScienceClubStatus.active` instead of excluding `archived`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for a3ae749a3b7aa0d76e685103018df925b7a20658. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->