### PR TITLE
fix: remove stop button from player widgets

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -53,6 +53,7 @@ Future<void> runToPWR() async {
       androidNotificationChannelId: "com.solvro.topwr.audio",
       androidNotificationChannelName: "Audio playback",
       androidNotificationOngoing: true,
+      showStopAction: false,
     );
   } on PlatformException catch (e, st) {
     await Sentry.captureException(e, stackTrace: st);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -114,7 +114,11 @@ dependencies:
 
   #Audio
   just_audio: ^0.10.5
-  just_audio_background: ^0.0.1-beta.17
+  just_audio_background:
+    git:
+      url: https://github.com/24bartixx/just_audio.git
+      path: just_audio_background
+      ref: a7cf5a2e2a1bcf5f1c7e37e7047d02e7a88e1453
 
   #Other
   in_app_update: ^4.2.3


### PR DESCRIPTION
# Screenshots
<img width="250"  alt="image" src="https://github.com/user-attachments/assets/73609fe2-d737-41d5-9123-ed8a303ceb25" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/d8c70e6a-e23e-4765-9036-1246db3baebb" />



<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes stop button from audio player widgets and updates `just_audio_background` dependency to a specific commit.
> 
>   - **Behavior**:
>     - Removes stop button from audio player widgets by setting `showStopAction: false` in `JustAudioBackground.init` in `main.dart`.
>   - **Dependencies**:
>     - Updates `just_audio_background` dependency in `pubspec.yaml` to a specific commit from a GitHub repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for d5d028fe84d22375405174ee2fb7c1ccef1d0480. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->