### PR TITLE
feat: radio player global widget

### DIFF
--- a/lib/features/digital_guide/tabs/doors/presentation/door_view.dart
+++ b/lib/features/digital_guide/tabs/doors/presentation/door_view.dart
@@ -82,7 +82,7 @@ class _DoorsView extends ConsumerWidget {
       ),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
+++ b/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
@@ -7,6 +7,7 @@ import "../../../../../config/ui_config.dart";
 import "../../../../../theme/app_theme.dart";
 import "../../../../../utils/context_extensions.dart";
 import "../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../navigator/utils/navigation_commands.dart";
 import "../../../presentation/widgets/accessibility_button.dart";
 import "../../../presentation/widgets/accessibility_profile_card.dart";
@@ -69,7 +70,7 @@ class DigitalGuideEntranceDetailsView extends ConsumerWidget {
       const SizedBox(height: DigitalGuideConfig.heightMedium),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/corridor_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/corridor_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
@@ -69,7 +70,7 @@ class CorridorView extends ConsumerWidget {
         ),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/dressing_room_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/dressing_room_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/digital_guide_photo_row.dart";
@@ -23,7 +24,7 @@ class DressingRoomView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final dressingRoomInformation = dressingRoom.translations.pl;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/information_point_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/information_point_view.dart
@@ -6,6 +6,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
@@ -22,7 +23,7 @@ class InformationPointView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.localize;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: DigitalGuideConfig.symetricalPaddingBig,

--- a/lib/features/digital_guide/tabs/structure/presentation/views/level_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/level_view.dart
@@ -6,6 +6,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
 import "../../../../data/models/level_with_regions.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
@@ -18,7 +19,7 @@ class LevelView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/lodge_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/lodge_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/digital_guide_photo_row.dart";
@@ -23,7 +24,7 @@ class LodgeView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final lodgeInformation = lodge.translations.pl;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.all(DigitalGuideConfig.paddingBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/parking_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/parking_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../../presentation/widgets/bullet_list.dart";
@@ -23,7 +24,7 @@ class ParkingView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final DigitalGuideParkingTranslation parkingsInformation = parking.translations.plTranslation;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/railings_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/railings_view.dart
@@ -48,7 +48,7 @@ class _RailingsView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/ramps_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/ramps_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
@@ -25,7 +26,7 @@ class RampsView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final RampTranslation rampsInformation = ramps.translations.plTranslation;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/region_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/region_view.dart
@@ -6,6 +6,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../../widgets/loading_widgets/shimmer_loading.dart";
 import "../../../../../../widgets/my_error_widget.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
@@ -114,7 +115,7 @@ class _RegionView extends ConsumerWidget {
       ),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/stairs_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/stairs_view.dart
@@ -50,7 +50,7 @@ class _StairsView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final StairsTranslation stairsInformation = stairs.translations.plTranslation;
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
@@ -66,7 +67,7 @@ class StairwayView extends ConsumerWidget {
         separatorBuilder: (context, index) => const SizedBox(height: DigitalGuideConfig.heightMedium),
       ),
     ];
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/toilets_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/toilets_view.dart
@@ -7,6 +7,7 @@ import "../../../../../../config/ui_config.dart";
 import "../../../../../../theme/app_theme.dart";
 import "../../../../../../utils/context_extensions.dart";
 import "../../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../../../navigator/utils/navigation_commands.dart";
 import "../../../../presentation/widgets/accessibility_button.dart";
 import "../../../../presentation/widgets/accessibility_profile_card.dart";
@@ -25,7 +26,7 @@ class ToiletsView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ToiletTranslation toiletsInformation = toilet.translations.plTranslation;
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.paddingBig),

--- a/lib/features/digital_guide/tabs/transportation/presentation/transportation_detail_view.dart
+++ b/lib/features/digital_guide/tabs/transportation/presentation/transportation_detail_view.dart
@@ -8,6 +8,7 @@ import "../../../../../theme/app_theme.dart";
 import "../../../../../utils/context_extensions.dart";
 import "../../../../../utils/type_converter.dart";
 import "../../../../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../../../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../../presentation/widgets/accessibility_button.dart";
 import "../../../presentation/widgets/accessibility_profile_card.dart";
 import "../../../presentation/widgets/bullet_list.dart";
@@ -78,7 +79,7 @@ class TransportationDetailView extends ConsumerWidget {
       ),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: [AccessibilityButton()]),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.heightBig),

--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -9,6 +9,7 @@ import "../../theme/app_theme.dart";
 import "../../utils/context_extensions.dart";
 import "../../widgets/date_chip.dart";
 import "../../widgets/detail_views/detail_view_app_bar.dart";
+import "../../widgets/horizontal_symmetric_safe_area.dart";
 import "../../widgets/loading_widgets/shimmer_loading.dart";
 import "../../widgets/loading_widgets/simple_previews/preview_text_prototype.dart";
 import "../../widgets/my_error_widget.dart";
@@ -31,7 +32,7 @@ class GuideDetailView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: context.localize.guide_detail_view_description,
-      child: Scaffold(
+      child: HorizontalSymmetricSafeAreaScaffold(
         appBar: DetailViewAppBar(),
         body: _GuideDetailDataView(id: id),
       ),

--- a/lib/features/science_club/science_clubs_filters/widgets/filters_fab.dart
+++ b/lib/features/science_club/science_clubs_filters/widgets/filters_fab.dart
@@ -30,17 +30,14 @@ class FiltersFAB extends ConsumerWidget {
           builder: (context) => UncontrolledProviderScope(container: parentProvider, child: const FiltersSheet()),
         );
       },
-      backgroundColor: isActive ? context.colorTheme.orangePomegranade : context.colorTheme.whiteSoap,
+      backgroundColor: context.colorTheme.orangePomegranadeLighter,
       child: Semantics(
         label: context.localize.filters_fab_tooltip,
         child: Stack(
           children: [
             Padding(
               padding: const EdgeInsets.all(8),
-              child: Icon(
-                Icons.tune,
-                color: !isActive ? context.colorTheme.orangePomegranade : context.colorTheme.whiteSoap,
-              ),
+              child: Icon(Icons.tune, color: context.colorTheme.whiteSoap),
             ),
             if (isActive)
               Positioned(top: 4, right: 4, child: Icon(Icons.circle, size: 8, color: context.colorTheme.whiteSoap)),

--- a/lib/features/science_club/science_clubs_view/widgets/sci_clubs_scaffold.dart
+++ b/lib/features/science_club/science_clubs_view/widgets/sci_clubs_scaffold.dart
@@ -30,17 +30,8 @@ class SciClubsScaffold extends ConsumerWidget {
           unawaited(ref.trackEvent(ClarityEvents.searchSciClub));
         },
       ),
-      body: Stack(
-        children: [
-          ?child,
-          if (showFab)
-            Positioned(
-              right: 16, // the left view padding is applied globally
-              bottom: MediaQuery.viewPaddingOf(context).bottom + 16,
-              child: const FiltersFAB(),
-            ),
-        ],
-      ),
+      body: child ?? const SizedBox.shrink(),
+      extraFabs: const [FiltersFAB()],
     );
   }
 }

--- a/lib/features/settings/settings_view.dart
+++ b/lib/features/settings/settings_view.dart
@@ -13,6 +13,7 @@ import "../../../../theme/app_theme.dart";
 import "../../../../utils/context_extensions.dart";
 import "../../gen/assets.gen.dart";
 import "../../services/translations_service/data/preferred_lang_repository.dart";
+import "../../widgets/horizontal_symmetric_safe_area.dart";
 import "../branches/data/model/branch.dart";
 import "../branches/data/repository/branch_repository.dart";
 import "../branches/presentation/branch_dialog.dart";
@@ -69,7 +70,7 @@ class SettingsView extends ConsumerWidget {
       ),
     ];
 
-    return Scaffold(
+    return HorizontalSymmetricSafeAreaScaffold(
       backgroundColor: context.colorTheme.whiteSoap,
       appBar: DetailViewAppBar(title: (text: context.localize.settings, context: context)),
       body: Padding(

--- a/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
+++ b/lib/features/sks/sks_menu/presentation/sks_menu_screen.dart
@@ -59,7 +59,7 @@ class SksMenuView extends HookConsumerWidget {
         appBar: DetailViewAppBar(actions: const [SksUserDataButton()]),
         body: MyErrorWidget(error, stackTrace: stackTrace),
       ),
-      loading: () => HorizontalSymmetricSafeAreaScaffold(body: const Center(child: SksMenuViewLoading())),
+      loading: () => const HorizontalSymmetricSafeAreaScaffold(body: Center(child: SksMenuViewLoading())),
     );
   }
 }
@@ -77,13 +77,15 @@ class _SksMenuView extends ConsumerWidget {
     }
     return HorizontalSymmetricSafeAreaScaffold(
       appBar: DetailViewAppBar(actions: const [SksUserDataButton()]),
-      floatingActionButton: FloatingActionButton(
-        heroTag: "favouriteDishesFab",
-        elevation: 3,
-        backgroundColor: context.colorTheme.orangePomegranadeLighter,
-        onPressed: ref.navigateToSksFavouriteDishes,
-        child: Icon(Icons.favorite, color: context.colorTheme.whiteSoap),
-      ),
+      extraFabs: [
+        FloatingActionButton(
+          heroTag: "favouriteDishesFab",
+          elevation: 3,
+          backgroundColor: context.colorTheme.orangePomegranadeLighter,
+          onPressed: ref.navigateToSksFavouriteDishes,
+          child: Icon(Icons.favorite, color: context.colorTheme.whiteSoap),
+        ),
+      ],
       body: RefreshIndicator(
         onRefresh: () async {
           // ignore: unused_result

--- a/lib/widgets/horizontal_symmetric_safe_area.dart
+++ b/lib/widgets/horizontal_symmetric_safe_area.dart
@@ -3,7 +3,11 @@ import "dart:math";
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../features/navigator/app_router.dart";
 import "../features/navigator/navigation_stack.dart";
+import "../features/navigator/utils/navigation_commands.dart";
+import "../features/radio_luz/service/radio_player_controller.dart";
+import "../theme/app_theme.dart";
 
 extension MediaQueryPaddingExtensionX on BuildContext {
   EdgeInsets get maxOfHorizontalViewPaddings {
@@ -28,13 +32,59 @@ class HorizontalSymmetricSafeArea extends ConsumerWidget {
   }
 }
 
-class HorizontalSymmetricSafeAreaScaffold extends Scaffold {
-  HorizontalSymmetricSafeAreaScaffold({
+class HorizontalSymmetricSafeAreaScaffold extends ConsumerWidget {
+  const HorizontalSymmetricSafeAreaScaffold({
     super.key,
-    required Widget body,
-    super.floatingActionButton,
-    super.bottomNavigationBar,
-    super.appBar,
-    super.backgroundColor,
-  }) : super(body: HorizontalSymmetricSafeArea(child: body));
+    required this.body,
+    this.bottomNavigationBar,
+    this.appBar,
+    this.backgroundColor,
+    this.extraFabs,
+  });
+
+  final Widget body;
+  final Widget? bottomNavigationBar;
+  final PreferredSizeWidget? appBar;
+  final Color? backgroundColor;
+  final List<Widget>? extraFabs;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shouldDisplayRadio =
+        ref.watch(radioControllerProvider).isPlaying &&
+        ref.watch(currentRouteProvider)?.settings.name != RadioLuzRoute.name;
+
+    final fabs = <Widget>[
+      if (shouldDisplayRadio)
+        FloatingActionButton(
+          heroTag: "radioFab",
+          elevation: 3,
+          backgroundColor: context.colorTheme.orangePomegranadeLighter,
+          onPressed: () async {
+            await ref.navigateToRadioLuz();
+          },
+          child: const Icon(Icons.radio),
+        ),
+      ...?extraFabs,
+    ];
+
+    return Scaffold(
+      appBar: appBar,
+      bottomNavigationBar: bottomNavigationBar,
+      backgroundColor: backgroundColor,
+      body: HorizontalSymmetricSafeArea(child: body),
+      floatingActionButton: fabs.isNotEmpty ? _FloatingActionButtons(fabs: fabs) : null,
+    );
+  }
+}
+
+class _FloatingActionButtons extends StatelessWidget {
+  const _FloatingActionButtons({required this.fabs});
+
+  final List<Widget> fabs;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(mainAxisSize: MainAxisSize.min, spacing: 8, children: [for (final fab in fabs) fab]);
+  }
 }


### PR DESCRIPTION
Added global button
From now on, all new views have to be wrapped inside HorizontalSymmetricSafeAreaScaffold
Btw animations work as they should


https://github.com/user-attachments/assets/2af82fa2-0947-4062-8c30-dbe9a0bc447d


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduce `HorizontalSymmetricSafeAreaScaffold` for consistent view layout with optional FABs and update `FiltersFAB` UI.
> 
>   - **Widgets**:
>     - Introduce `HorizontalSymmetricSafeAreaScaffold` in `horizontal_symmetric_safe_area.dart` to replace `Scaffold` in views, adding horizontal padding and optional FABs.
>     - Update `HorizontalSymmetricSafeAreaScaffold` to include a radio player FAB when playing, and support additional FABs.
>   - **Views**:
>     - Replace `Scaffold` with `HorizontalSymmetricSafeAreaScaffold` in `door_view.dart`, `entraces_detail_view.dart`, `corridor_view.dart`, and 18 other views.
>   - **UI Adjustments**:
>     - Change `FiltersFAB` background color to `orangePomegranadeLighter` and icon color to `whiteSoap`.
>     - Modify `SciClubsScaffold` to use `extraFabs` for additional FABs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 7f2ca0cf1d7f83a071aa16dae98abb4bbd8c3a3f. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->