### PR TITLE
fix: move action button

### DIFF
--- a/lib/features/radio_luz/presentation/audio_player_widget.dart
+++ b/lib/features/radio_luz/presentation/audio_player_widget.dart
@@ -38,13 +38,13 @@ class AudioPlayerWidget extends HookConsumerWidget {
             child: Row(
               spacing: RadioLuzConfig.spacingMedium,
               children: [
+                RadioPlayerSlider(radioController: radioController, volume: radioState.volume),
+                const RadioPlayerInfo(),
                 RadioPlayerControlButton(
                   radioController: radioController,
                   isLoading: radioState.isLoading,
                   isPlaying: radioState.isPlaying,
                 ),
-                RadioPlayerSlider(radioController: radioController, volume: radioState.volume),
-                const RadioPlayerInfo(),
               ],
             ),
           ),


### PR DESCRIPTION
<img width="300"  alt="B8D537F0-4ACD-4E74-832F-BDD710686C6C" src="https://github.com/user-attachments/assets/2730e8b9-de4a-4edd-9936-9ad751405f42" />


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reorder components in `AudioPlayerWidget` to move `RadioPlayerControlButton` after `RadioPlayerSlider` and `RadioPlayerInfo`.
> 
>   - **UI Layout**:
>     - Reorder components in `Row` within `AudioPlayerWidget` in `audio_player_widget.dart`.
>     - Move `RadioPlayerControlButton` to be after `RadioPlayerSlider` and `RadioPlayerInfo`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 4c611cc5e87579a1636cb9985bc9b33470b9fde9. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->