### PR TITLE
fix(digital-guide): alt titles amendments

### DIFF
--- a/lib/features/digital_guide/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide/presentation/digital_guide_view.dart
@@ -65,10 +65,7 @@ class _DigitalGuideView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final widgets1 = [
       const SizedBox(height: DigitalGuideConfig.heightSmall),
-      SizedBox(
-        height: DetailViewsConfig.imageHeight,
-        child: ZoomableCachedImage(photoUrl, semanticsLabel: context.localize.building_prefix),
-      ),
+      SizedBox(height: DetailViewsConfig.imageHeight, child: ZoomableCachedImage(photoUrl)),
       HeadlinesSection(
         name: digitalGuideData.translations.plTranslation.name,
         description: digitalGuideData.translations.plTranslation.extendedName,

--- a/lib/features/digital_guide/presentation/widgets/digital_guide_carousel.dart
+++ b/lib/features/digital_guide/presentation/widgets/digital_guide_carousel.dart
@@ -11,16 +11,10 @@ import "../../../../utils/context_extensions.dart";
 import "digital_guide_image.dart";
 
 class DigitalGuideCarouselWithIndicator extends HookWidget {
-  const DigitalGuideCarouselWithIndicator({
-    super.key,
-    required this.imgListId,
-    this.initId,
-    required this.semanticsLabel,
-  });
+  const DigitalGuideCarouselWithIndicator({super.key, required this.imgListId, this.initId});
 
   final IList<int> imgListId;
   final int? initId;
-  final String semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -41,7 +35,7 @@ class DigitalGuideCarouselWithIndicator extends HookWidget {
                     maxScale: 5,
                     child: ClipRRect(
                       borderRadius: const BorderRadius.all(Radius.circular(DigitalGuideConfig.borderRadiusMedium)),
-                      child: DigitalGuideImage(id: item, zoomable: false, semanticsLabel: semanticsLabel),
+                      child: DigitalGuideImage(id: item, zoomable: false),
                     ),
                   ),
                 )

--- a/lib/features/digital_guide/presentation/widgets/digital_guide_image.dart
+++ b/lib/features/digital_guide/presentation/widgets/digital_guide_image.dart
@@ -8,19 +8,16 @@ import "../../../../widgets/zoomable_images.dart";
 import "../../data/repository/image_repository.dart";
 
 class DigitalGuideImage extends ConsumerWidget {
-  const DigitalGuideImage({required this.id, this.zoomable = true, this.semanticsLabel});
+  const DigitalGuideImage({required this.id, this.zoomable = true});
 
   final int id;
   final bool zoomable;
-  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncImageUrl = ref.watch(imageRepositoryProvider(id));
     return asyncImageUrl.when(
-      data: (url) => zoomable
-          ? ZoomableCachedImage(url, semanticsLabel: semanticsLabel)
-          : MyCachedImage(url, semanticsLabel: semanticsLabel),
+      data: (url) => zoomable ? ZoomableCachedImage(url) : MyCachedImage(url),
       error: (error, stackTrace) => MyErrorWidget(error, stackTrace: stackTrace),
       loading: () => Center(
         child: ShimmeringEffect(child: Container(color: Colors.white)),

--- a/lib/features/digital_guide/presentation/widgets/digital_guide_photo_row.dart
+++ b/lib/features/digital_guide/presentation/widgets/digital_guide_photo_row.dart
@@ -12,8 +12,7 @@ import "digital_guide_nav_link.dart";
 class DigitalGuidePhotoRow extends StatelessWidget {
   final IList<int> imagesIDs;
 
-  const DigitalGuidePhotoRow({super.key, required this.imagesIDs, required this.semanticsLabel});
-  final String semanticsLabel;
+  const DigitalGuidePhotoRow({super.key, required this.imagesIDs});
 
   @override
   Widget build(BuildContext context) {
@@ -23,63 +22,58 @@ class DigitalGuidePhotoRow extends StatelessWidget {
 
     final displayImages = imagesIDs.take(3).toIList();
 
-    return Column(
-      children: [
-        SizedBox(
-          height: DigitalGuideConfig.photoRowHeight,
-          child: Row(
-            children: displayImages
-                .map(
-                  (id) => Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.paddingSmall),
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
-                        child: Semantics(
-                          label: semanticsLabel,
-                          image: true,
-                          container: true,
-                          button: true,
-                          child: ExcludeSemantics(
-                            child: GestureDetector(
-                              onTap: () async {
-                                if (imagesIDs.length > 1) {
-                                  await showGallery(context, initId: id, semanticsLabel: semanticsLabel);
-                                }
-                              },
-                              child: DigitalGuideImage(id: id, zoomable: imagesIDs.length == 1),
+    return ExcludeSemantics(
+      child: Column(
+        children: [
+          SizedBox(
+            height: DigitalGuideConfig.photoRowHeight,
+            child: Row(
+              children: displayImages
+                  .map(
+                    (id) => Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: DigitalGuideConfig.paddingSmall),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
+                          child: Semantics(
+                            image: true,
+                            container: true,
+                            button: true,
+                            child: ExcludeSemantics(
+                              child: GestureDetector(
+                                onTap: () async {
+                                  if (imagesIDs.length > 1) {
+                                    await showGallery(context, initId: id);
+                                  }
+                                },
+                                child: DigitalGuideImage(id: id, zoomable: imagesIDs.length == 1),
+                              ),
                             ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                )
-                .toList(),
+                  )
+                  .toList(),
+            ),
           ),
-        ),
-        if (imagesIDs.length > 3)
-          Semantics(
-            image: true,
-            button: true,
-            container: true,
-            child: Padding(
+          if (imagesIDs.length > 3)
+            Padding(
               padding: const EdgeInsets.only(top: DigitalGuideConfig.heightSmall),
               child: DigitalGuideNavLink(
-                onTap: () => showGallery(context, semanticsLabel: semanticsLabel),
+                onTap: () => showGallery(context),
                 text: context.localize.see_all_photos(imagesIDs.length),
               ),
             ),
-          ),
-      ],
+        ],
+      ),
     );
   }
 
-  Future<void> showGallery(BuildContext context, {int? initId, required String semanticsLabel}) async {
+  Future<void> showGallery(BuildContext context, {int? initId}) async {
     await showDialog<void>(
       context: context,
-      builder: (context) =>
-          DigitalGuideCarouselWithIndicator(imgListId: imagesIDs, initId: initId, semanticsLabel: semanticsLabel),
+      builder: (context) => DigitalGuideCarouselWithIndicator(imgListId: imagesIDs, initId: initId),
     );
   }
 }

--- a/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_detail_view.dart
+++ b/lib/features/digital_guide/tabs/adapted_toilets/presentation/adapted_toilet_detail_view.dart
@@ -54,10 +54,7 @@ class AdaptedToiletDetailView extends ConsumerWidget {
       if (adaptedToilet.imagesIndices.isNotEmpty)
         Padding(
           padding: const EdgeInsets.symmetric(vertical: DigitalGuideConfig.paddingMedium),
-          child: DigitalGuidePhotoRow(
-            imagesIDs: adaptedToilet.imagesIndices,
-            semanticsLabel: context.localize.adapted_toilet,
-          ),
+          child: DigitalGuidePhotoRow(imagesIDs: adaptedToilet.imagesIndices),
         ),
       if (adaptedToilet.doorsIndices.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
       ListView.separated(

--- a/lib/features/digital_guide/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
+++ b/lib/features/digital_guide/tabs/dressing_room/presentation/digital_guide_dressing_rooms_expansion_tile.dart
@@ -90,10 +90,7 @@ class _DigitalGuideDressingRoomsExpansionTileContent extends StatelessWidget {
               ),
             ),
           if (dressingRoomInformation.comment.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
-          DigitalGuidePhotoRow(
-            imagesIDs: dressingRoom!.imagesIds?.toIList() ?? const IList.empty(),
-            semanticsLabel: context.localize.dressing_room,
-          ),
+          DigitalGuidePhotoRow(imagesIDs: dressingRoom!.imagesIds?.toIList() ?? const IList.empty()),
           const SizedBox(height: DigitalGuideConfig.heightSmall),
           Semantics(
             container: true,

--- a/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
+++ b/lib/features/digital_guide/tabs/entraces/presentation/entraces_detail_view.dart
@@ -65,7 +65,7 @@ class DigitalGuideEntranceDetailsView extends ConsumerWidget {
         shrinkWrap: true,
       ),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
-      DigitalGuidePhotoRow(imagesIDs: entrance.imagesIndices, semanticsLabel: context.localize.entrance),
+      DigitalGuidePhotoRow(imagesIDs: entrance.imagesIndices),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
     ];
 

--- a/lib/features/digital_guide/tabs/evacuation/evacuation_widget.dart
+++ b/lib/features/digital_guide/tabs/evacuation/evacuation_widget.dart
@@ -27,7 +27,7 @@ class EvacuationWidget extends StatelessWidget {
         style: context.textTheme.boldBody.copyWith(height: DigitalGuideConfig.accessibleLineHeight),
       ),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
-      DigitalGuideImage(id: digitalGuideData.evacuationMapId, semanticsLabel: context.localize.evacuation),
+      DigitalGuideImage(id: digitalGuideData.evacuationMapId),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
       EntrancesList(digitalGuideData),
     ];

--- a/lib/features/digital_guide/tabs/lifts/presentation/digital_guide_lift_detail_view.dart
+++ b/lib/features/digital_guide/tabs/lifts/presentation/digital_guide_lift_detail_view.dart
@@ -66,7 +66,7 @@ class DigitalGuideLiftDetailView extends ConsumerWidget {
                     padding: const EdgeInsets.all(DigitalGuideConfig.heightMedium),
                     child: ClipRRect(
                       borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusSmall),
-                      child: DigitalGuideImage(id: lift.imagesIds![index], semanticsLabel: context.localize.lift),
+                      child: DigitalGuideImage(id: lift.imagesIds![index]),
                     ),
                   );
                 }, childCount: lift.imagesIds!.length),

--- a/lib/features/digital_guide/tabs/localization/presentation/localization_expansion_tile_content.dart
+++ b/lib/features/digital_guide/tabs/localization/presentation/localization_expansion_tile_content.dart
@@ -25,10 +25,7 @@ class LocalizationExpansionTileContent extends ConsumerWidget {
           padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),
           child: ClipRRect(
             borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
-            child: DigitalGuideImage(
-              id: digitalGuideData.locationMapId,
-              semanticsLabel: context.localize.localization_digital_guide_image_screen_reader_label,
-            ),
+            child: DigitalGuideImage(id: digitalGuideData.locationMapId),
           ),
         ),
         Padding(

--- a/lib/features/digital_guide/tabs/lodge/presentation/digital_guide_lodge_expansion_tile_content.dart
+++ b/lib/features/digital_guide/tabs/lodge/presentation/digital_guide_lodge_expansion_tile_content.dart
@@ -90,10 +90,7 @@ class _DigitalGuideLodgeExpansionTileContent extends StatelessWidget {
               ),
             ),
           if (lodgeInformation.comment.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
-          DigitalGuidePhotoRow(
-            imagesIDs: lodge!.imagesIds?.toIList() ?? const IList.empty(),
-            semanticsLabel: context.localize.lodge,
-          ),
+          DigitalGuidePhotoRow(imagesIDs: lodge!.imagesIds?.toIList() ?? const IList.empty()),
           Semantics(
             container: true,
 

--- a/lib/features/digital_guide/tabs/rooms/presentation/digital_guide_room_detail_view.dart
+++ b/lib/features/digital_guide/tabs/rooms/presentation/digital_guide_room_detail_view.dart
@@ -60,7 +60,7 @@ class DigitalGuideRoomDetailView extends ConsumerWidget {
         backgroundColor: context.colorTheme.whiteSoap,
       ),
       if (room.imagesIds != null && room.imagesIds!.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
-      DigitalGuidePhotoRow(imagesIDs: room.imagesIds.toIList(), semanticsLabel: context.localize.alt_room_information),
+      DigitalGuidePhotoRow(imagesIDs: room.imagesIds.toIList()),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
       ListView.separated(
         physics: const NeverScrollableScrollPhysics(),

--- a/lib/features/digital_guide/tabs/structure/presentation/views/corridor_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/corridor_view.dart
@@ -53,7 +53,7 @@ class CorridorView extends ConsumerWidget {
       if (corridor.imagesIndices.isNotEmpty)
         Padding(
           padding: const EdgeInsets.symmetric(vertical: DigitalGuideConfig.paddingMedium),
-          child: DigitalGuidePhotoRow(imagesIDs: corridor.imagesIndices, semanticsLabel: context.localize.corridor),
+          child: DigitalGuidePhotoRow(imagesIDs: corridor.imagesIndices),
         ),
       if (corridor.doorsIndices.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
       if (corridor.doorsIndices.isNotEmpty)

--- a/lib/features/digital_guide/tabs/structure/presentation/views/dressing_room_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/dressing_room_view.dart
@@ -54,10 +54,7 @@ class DressingRoomView extends ConsumerWidget {
               ),
             Text(dressingRoomInformation.comment),
             if (dressingRoomInformation.comment.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
-            DigitalGuidePhotoRow(
-              imagesIDs: dressingRoom.imagesIds?.toIList() ?? const IList.empty(),
-              semanticsLabel: context.localize.dressing_room,
-            ),
+            DigitalGuidePhotoRow(imagesIDs: dressingRoom.imagesIds?.toIList() ?? const IList.empty()),
             const SizedBox(height: DigitalGuideConfig.heightSmall),
             AccessibilityProfileCard(
               accessibilityCommentsManager: DressingRoomAccessibilityCommentsManager(

--- a/lib/features/digital_guide/tabs/structure/presentation/views/lodge_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/lodge_view.dart
@@ -65,10 +65,7 @@ class LodgeView extends ConsumerWidget {
               ),
             Semantics(container: true, child: Text(lodgeInformation.comment)),
             if (lodgeInformation.comment.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
-            DigitalGuidePhotoRow(
-              imagesIDs: lodge.imagesIds?.toIList() ?? const IList.empty(),
-              semanticsLabel: context.localize.lodge,
-            ),
+            DigitalGuidePhotoRow(imagesIDs: lodge.imagesIds?.toIList() ?? const IList.empty()),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: DigitalGuideConfig.paddingBig),
               child: AccessibilityProfileCard(

--- a/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
+++ b/lib/features/digital_guide/tabs/structure/presentation/views/stairway_view.dart
@@ -41,7 +41,7 @@ class StairwayView extends ConsumerWidget {
       if (stairway.imagesIds.isNotEmpty)
         Padding(
           padding: const EdgeInsets.symmetric(vertical: DigitalGuideConfig.paddingMedium),
-          child: DigitalGuidePhotoRow(imagesIDs: stairway.imagesIds, semanticsLabel: context.localize.stairs),
+          child: DigitalGuidePhotoRow(imagesIDs: stairway.imagesIds),
         ),
       if (stairway.stairsIds.isNotEmpty) const SizedBox(height: DigitalGuideConfig.heightMedium),
       ListView.separated(

--- a/lib/features/digital_guide/tabs/surrounding/presentation/surroundings_expansion_tile_content.dart
+++ b/lib/features/digital_guide/tabs/surrounding/presentation/surroundings_expansion_tile_content.dart
@@ -66,7 +66,7 @@ class _SurroundingExpansionTileContent extends ConsumerWidget {
         ),
       ),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
-      DigitalGuidePhotoRow(imagesIDs: surroundingResponse.images.lock, semanticsLabel: context.localize.surroundings),
+      DigitalGuidePhotoRow(imagesIDs: surroundingResponse.images.lock),
       const SizedBox(height: DigitalGuideConfig.heightMedium),
     ];
 

--- a/lib/features/digital_guide_objects/presentation/digital_g_objects_featers_list.dart
+++ b/lib/features/digital_guide_objects/presentation/digital_g_objects_featers_list.dart
@@ -39,7 +39,7 @@ class DigitalGuideObjectsFeaturesSection extends ConsumerWidget {
                 padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),
                 child: MyHtmlWidget(tile.translations.pl.content, textStyle: context.textTheme.body),
               ),
-              DigitalGuidePhotoRow(imagesIDs: tile.images.lock, semanticsLabel: context.localize.surroundings),
+              DigitalGuidePhotoRow(imagesIDs: tile.images.lock),
             ],
           ),
     ];

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -574,7 +574,6 @@
   "version_dialog_semantics_label": "app version: ",
   "legalese_dialog_semantics_label": "legalese info:",
   "fullscreen_image": " - fullscreen",
-  "localization_digital_guide_image_screen_reader_label": "Building's location map",
   "toilet": "Toilet",
   "audio_message_comment_screen_reader": "To play the message, click the play button.",
   "audio_player_slider": "Playback slider. {value} percent.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3437,10 +3437,6 @@
   "@fullscreen_image": {
     "description": "Semantics read for fullscreen image"
   },
-  "localization_digital_guide_image_screen_reader_label": "Mapa lokalizacji budynku",
-  "@localization_digital_guide_image_screen_reader_label": {
-    "description": "Text read for localization digital guide image screen reader label"
-  },
   "toilet": "Toaleta",
   "@toilet": {
     "description": "Label for toilet"


### PR DESCRIPTION
digital guide does not provider alt descriptions for images practically so we have to rely on ours
Looks like they didn't realy bother to provide them

<img width="371" height="57" alt="image" src="https://github.com/user-attachments/assets/85f9d735-7d72-4c9e-931b-cb91884ceb35" />
<img width="372" height="53" alt="image" src="https://github.com/user-attachments/assets/117a0879-5114-4de2-af16-e5c30ae8dff1" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds and updates semantics labels for images in the digital guide to improve accessibility.
> 
>   - **Behavior**:
>     - Adds `semanticsLabel` to `DigitalGuideImage` in `digital_guide_image.dart` and `DigitalGuidePhotoRow` in `digital_guide_photo_row.dart`.
>     - Updates `semanticsLabel` for `DigitalGuidePhotoRow` in `adapted_toilet_detail_view.dart`, `entraces_detail_view.dart`, and `digital_guide_room_detail_view.dart`.
>     - Adds `semanticsLabel` to `DigitalGuideImage` in `digital_guide_lift_detail_view.dart`.
>   - **Localization**:
>     - Adds new entries for `entrance`, `adapted_toilet`, and `alt_room_information` in `app_en.arb` and `app_pl.arb`.
>   - **Misc**:
>     - Refactors `MyCachedImage` in `my_cached_image.dart` to handle empty `semanticsLabel` by excluding semantics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for b75c7dfbbf12b3dcedbb6fa3f8805f4a9749e071. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->