### PR TITLE
fix: psychological aid error

### DIFF
--- a/lib/features/guide_detail_view/guide_detail_view.dart
+++ b/lib/features/guide_detail_view/guide_detail_view.dart
@@ -53,6 +53,10 @@ class _GuideDetailDataView extends ConsumerWidget {
       AsyncValue(:final GuideDetails value) => Builder(
         builder: (context) {
           final lastModifiedDate = context.getTheLatestUpdatedDateGuide(questions: value.guideQuestions);
+          final createAtDate = context.getTheLatesCreatedDateGuide(
+            questions: value.guideQuestions,
+            locale: context.locale,
+          );
           final IList<String> authorsNames = value.guideAuthors
               .where((e) => e.role.role == GuideAuthorRoleType.author)
               .map((a) => a.name)
@@ -76,17 +80,20 @@ class _GuideDetailDataView extends ConsumerWidget {
                         child: ZoomableRestApiImage(value.image, useFullImageQuality: true),
                       ),
                     ),
-                    Positioned(
-                      top: GuideDetailViewConfig.paddingMedium,
-                      right: GuideDetailViewConfig.paddingSmall,
-                      child: Tooltip(
-                        message: context.localize.last_modified,
-                        child: TooltipOnTap(
+                    if (lastModifiedDate != null)
+                      Positioned(
+                        top: GuideDetailViewConfig.paddingMedium,
+                        right: GuideDetailViewConfig.paddingSmall,
+                        child: Tooltip(
                           message: context.localize.last_modified,
-                          child: DateChip(date: lastModifiedDate),
+                          child: TooltipOnTap(
+                            message: context.localize.last_modified,
+                            child: DateChip(date: lastModifiedDate),
+                          ),
                         ),
-                      ),
-                    ),
+                      )
+                    else
+                      const SizedBox.shrink(),
                   ],
                 ),
                 automaticallyImplyLeading: false,
@@ -142,12 +149,16 @@ class _GuideDetailDataView extends ConsumerWidget {
                           ),
                         ),
                       Text(
-                        "${context.localize.created_at} ${context.getTheLatesCreatedDateGuide(questions: value.guideQuestions, locale: context.locale)}",
+                        createAtDate != null
+                            ? "${context.localize.created_at} $createAtDate"
+                            : context.localize.no_creation_date,
                         style: context.textTheme.bodyGrey,
                         textAlign: TextAlign.end,
                       ),
                       Text(
-                        "${context.localize.last_modified} ${DateFormat("dd.MM.yyyy", context.locale.countryCode).format(lastModifiedDate)}",
+                        lastModifiedDate != null
+                            ? "${context.localize.last_modified} ${DateFormat("dd.MM.yyyy", context.locale.countryCode).format(lastModifiedDate)}"
+                            : context.localize.no_modification_date,
                         style: context.textTheme.bodyGrey,
                         textAlign: TextAlign.end,
                       ),

--- a/lib/features/guide_detail_view/utils/get_the_latest_date.dart
+++ b/lib/features/guide_detail_view/utils/get_the_latest_date.dart
@@ -4,13 +4,21 @@ import "package:intl/intl.dart";
 import "../data/models/guide_details.dart";
 
 extension GetTheLatestDateGuideX on BuildContext {
-  String getTheLatesCreatedDateGuide({required IList<GuideQuestion> questions, required Locale locale}) {
+  String? getTheLatesCreatedDateGuide({required IList<GuideQuestion> questions, required Locale locale}) {
+    if (questions.isEmpty) {
+      return null;
+    }
+
     final newestDate = questions.map((e) => e.createdAt).reduce((a, b) => (a.isAfter(b)) ? a : b);
     final formatter = DateFormat("dd.MM.yyyy", locale.countryCode);
     return formatter.format(newestDate);
   }
 
-  DateTime getTheLatestUpdatedDateGuide({required IList<GuideQuestion> questions}) {
+  DateTime? getTheLatestUpdatedDateGuide({required IList<GuideQuestion> questions}) {
+    if (questions.isEmpty) {
+      return null;
+    }
+
     final newestDate = questions.map((e) => e.updatedAt).reduce((a, b) => (a.isAfter(b)) ? a : b);
     return newestDate;
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -642,5 +642,7 @@
   "pwr": "Wroclaw University of Science and Technology",
   "show_more": "show more",
   "radio_luz_description1": "Don't scroll. Listen.",
-  "radio_luz_description2": "Are you a creative person? Do you have an ear for music, a voice for the microphone, or a passion for reporting? We recruit twice a year — stay tuned."
+  "radio_luz_description2": "Are you a creative person? Do you have an ear for music, a voice for the microphone, or a passion for reporting? We recruit twice a year — stay tuned.",
+  "no_modification_date": "No update date found",
+  "no_creation_date": "No creation date found"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3740,5 +3740,13 @@
   "radio_luz_description2": "Jesteś twórczą osobą? Masz ucho do muzyki, głos do mikrofonu albo serce do reportażu? Rekrutujemy dwa razy do roku. Bądź z nami na bieżąco",
   "@radio_luz_description2": {
     "description": "Longer call-to-action inviting creative people to join Radio LUZ and informing about biannual recruitment"
+  },
+  "no_modification_date": "Nie znaleziono daty aktualizacji",
+  "@no_modification_date": {
+    "description": "Message displayed when no update date is found"
+  },
+  "no_creation_date": "Nie znaleziono daty utworzenia",
+  "@no_creation_date": {
+    "description": "Message displayed when no creation date is found"
   }
 }


### PR DESCRIPTION
### Fixed:
- psychological aid error
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-23 at 20 17 14" src="https://github.com/user-attachments/assets/eca537c2-ca83-4445-a0c3-981fa1914c7c" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-23 at 20 17 08" src="https://github.com/user-attachments/assets/ab7155c7-ff82-44d5-a8fa-8ac1e996d766" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes missing date error in guide detail view by adding null checks and updating localization for missing date messages.
> 
>   - **Behavior**:
>     - Fixes missing date error in `_GuideDetailDataView` in `guide_detail_view.dart` by adding null checks for `lastModifiedDate` and `createAtDate`.
>     - Displays `context.localize.no_creation_date` or `context.localize.no_modification_date` if dates are null.
>   - **Functions**:
>     - Updates `getTheLatesCreatedDateGuide()` and `getTheLatestUpdatedDateGuide()` in `get_the_latest_date.dart` to return `null` if `questions` list is empty.
>   - **Localization**:
>     - Adds `no_modification_date` and `no_creation_date` messages to `app_en.arb` and `app_pl.arb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 6eecfa2f62bd40f969134b4b52bd4f4bea4cb76f. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->