### PR TITLE
feat(radio-luz): deeplink to sci club details

### DIFF
--- a/lib/features/radio_luz/presentation/radio_luz_socials_section.dart
+++ b/lib/features/radio_luz/presentation/radio_luz_socials_section.dart
@@ -5,38 +5,15 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "../../../gen/assets.gen.dart";
 import "../../../theme/app_theme.dart";
 import "../../../utils/launch_url_util.dart";
-import "../../branches/data/model/branch.dart";
-import "../../navigator/utils/navigation_commands.dart";
-import "../../science_club/science_clubs_filters/model/sci_club_type.dart";
-import "../../science_club/science_clubs_view/model/science_clubs.dart";
 
-typedef SocialIconData = ({String assetPath, String url, bool inApp, ScienceClub? scienceClub});
+typedef SocialIconData = ({String assetPath, String url});
 
 final List<SocialIconData> _socialIconsData = [
-  (assetPath: Assets.svg.contactIcons.fb, url: "https://www.facebook.com/radioluz", inApp: false, scienceClub: null),
-  (
-    assetPath: Assets.svg.contactIcons.yt,
-    url: "https://www.youtube.com/@AkademickieRadioLUZ",
-    inApp: false,
-    scienceClub: null,
-  ),
-  (
-    assetPath: Assets.svg.logoAppBar,
-    url: "",
-    inApp: true,
-    scienceClub: const ScienceClub(
-      id: 1365,
-      name: "",
-      organizationStatus: ScienceClubStatus.active,
-      source: ScienceClubSource.manualEntry,
-      organizationType: ScienceClubType.studentOrganization,
-      coverPreview: false,
-      isStrategic: false,
-      branch: Branch.main,
-    ),
-  ),
-  (assetPath: Assets.svg.contactIcons.ig, url: "https://www.instagram.com/radio_luz/", inApp: false, scienceClub: null),
-  (assetPath: Assets.svg.contactIcons.web, url: "https://radioluz.pl/", inApp: false, scienceClub: null),
+  (assetPath: Assets.svg.contactIcons.fb, url: "https://www.facebook.com/radioluz"),
+  (assetPath: Assets.svg.contactIcons.yt, url: "https://www.youtube.com/@AkademickieRadioLUZ"),
+  (assetPath: Assets.svg.logoAppBar, url: "https://topwr.solvro.pl/sci-clubs/1365"),
+  (assetPath: Assets.svg.contactIcons.ig, url: "https://www.instagram.com/radio_luz/"),
+  (assetPath: Assets.svg.contactIcons.web, url: "https://radioluz.pl/"),
 ];
 
 class RadioLuzSocialsSection extends ConsumerWidget {
@@ -53,9 +30,7 @@ class RadioLuzSocialsSection extends ConsumerWidget {
         (index) => Padding(
           padding: EdgeInsets.only(right: index == _socialIconsData.length - 1 ? 0 : 16),
           child: InkWell(
-            onTap: () => _socialIconsData[index].inApp
-                ? ref.navigateSciClubsDetail(_socialIconsData[index].scienceClub!)
-                : ref.launch(_socialIconsData[index].url),
+            onTap: () => ref.launch(_socialIconsData[index].url),
             child: SvgPicture.asset(
               _socialIconsData[index].assetPath,
               width: iconSize,


### PR DESCRIPTION
Honestly, this is the only approach I could come up with. Other solutions would require deep modifications to other components. The only issue I foresee is if the ID changes on the backend.
Potential workarounds:
- Add a remote config for the ID (maybe dynamically linking it to an input on the frontend via a special button or tag?).
- Store the info in a static file (issue: can't be changed remotely).
- Search by name through the list of science clubs by name to get the ID (issue: potential latency/long loading times, and might fail in some cases).
- Create custom deep links for specific clubs (fetch clubs on app launch, generate links based on some tag (name?), and ensure the Radio Luz link remains static).

That’s all I can think of right now, though maybe there is a solution available that I’m not aware of. Let me know what you think
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add static deep link to specific science club in `radio_luz_socials_section.dart`.
> 
>   - **Behavior**:
>     - Adds a new deep link to `https://topwr.solvro.pl/sci-clubs/1365` in `_socialIconsData` in `radio_luz_socials_section.dart`.
>     - The link is static and may break if the ID changes on the backend.
>   - **Potential Issues**:
>     - Static ID in the URL could change, breaking the link.
>     - Suggested workarounds include remote config, static file storage, name-based search, or custom deep links.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 60eb8c2383b082dccc698a4e958ad7dfde673072. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->