### PR TITLE
fix: add decoration color for underlined links

### DIFF
--- a/lib/widgets/detail_views/contact_section.dart
+++ b/lib/widgets/detail_views/contact_section.dart
@@ -81,6 +81,7 @@ class _ContactIcon extends ConsumerWidget {
                   style: context.textTheme.bodyLarge?.copyWith(
                     color: url?.isNotEmpty ?? false ? context.colorScheme.primary : Colors.black,
                     decoration: url?.isNotEmpty ?? false ? TextDecoration.underline : TextDecoration.none,
+                    decorationColor: url?.isNotEmpty ?? false ? context.colorScheme.primary : null,
                     height: shouldBeAccessible
                         ? DigitalGuideConfig.accessibleLineHeight
                         : context.textTheme.bodyLarge?.copyWith(color: context.colorScheme.primary).height,


### PR DESCRIPTION
<img width="307" height="237" alt="Zrzut ekranu 2026-01-8 o 16 35 40" src="https://github.com/user-attachments/assets/2f232936-62e6-4d16-a6fc-df3637c8846a" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `decorationColor` to underlined links in `_ContactIcon` to match text color when URL is present.
> 
>   - **Behavior**:
>     - Adds `decorationColor` to underlined links in `_ContactIcon` in `contact_section.dart`.
>     - Uses `context.colorScheme.primary` for `decorationColor` when `url` is not empty, ensuring underline matches text color.
>   - **Misc**:
>     - No changes to logic or additional features, purely a visual enhancement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 3ba2ebca517c1a080b8bec5ec98760eb553e3634. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->