### PR TITLE
fix: revert home_widget version bump

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,7 +76,7 @@ dependencies:
   dotted_border: ^3.1.0
   fluttertoast: ^9.0.0
   carousel_slider_plus: ^7.1.1
-  home_widget: ^0.9.0
+  home_widget: ^0.8.1
   scrollable_positioned_list: ^0.3.8
   scrolls_to_top: ^2.1.1
   sliver_tools: ^0.2.12


### PR DESCRIPTION
Bump to home_widget 0.9.0 introduces breaking changes: [changelog](https://pub.dev/packages/home_widget/changelog).
This migration must be performed in order for the package to compile after update [steps to follow](https://docs.page/ABausG/home_widget/migrations/0.9.0). 
Reverting to the previous version for now.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert `home_widget` version to `0.8.1` in `pubspec.yaml` due to breaking changes in `0.9.0`.
> 
>   - **Dependency Reversion**:
>     - Revert `home_widget` version from `^0.9.0` to `^0.8.1` in `pubspec.yaml` due to breaking changes in the newer version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 947635df7b9cfcb29f36fb251f57b27aee06fb03. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->