### PR TITLE
fix(radio-luz): scroll issue

### DIFF
--- a/lib/features/radio_luz/presentation/now_playing_section.dart
+++ b/lib/features/radio_luz/presentation/now_playing_section.dart
@@ -60,55 +60,61 @@ class _NowPlayingTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = context.textTheme;
     final colorScheme = context.colorScheme;
-    return ListTileTheme(
-      child: ListTile(
-        horizontalTitleGap: 12,
-        visualDensity: VisualDensity.compact,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-        tileColor: isActive ? colorScheme.primary : colorScheme.surface,
-        dense: true,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-        leading: Text(
-          time,
-          style: textTheme.titleLarge?.copyWith(color: isActive ? colorScheme.surface : colorScheme.primary),
-        ),
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: textTheme.titleLarge?.copyWith(
-                      color: isActive ? colorScheme.surface : colorScheme.onTertiary,
-                    ),
+    return Container(
+      decoration: BoxDecoration(
+        color: isActive ? colorScheme.primary : colorScheme.surface,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Row(
+        children: [
+          Text(
+            time,
+            style: textTheme.titleLarge?.copyWith(color: isActive ? colorScheme.surface : colorScheme.primary),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        title,
+                        style: textTheme.titleLarge?.copyWith(
+                          color: isActive ? colorScheme.surface : colorScheme.onTertiary,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        style: textTheme.labelSmall?.copyWith(
+                          color: isActive ? colorScheme.surface : colorScheme.onTertiary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 2),
-                  Text(
-                    subtitle,
-                    style: textTheme.labelSmall?.copyWith(
-                      color: isActive ? colorScheme.surface : colorScheme.onTertiary,
-                    ),
+                ),
+                const SizedBox(width: 4),
+                if (isActive)
+                  LiveIndicator(
+                    spreadRadius: 8,
+                    spreadDuration: const Duration(milliseconds: 800),
+                    waitDuration: const Duration(seconds: 1),
+                    color: colorScheme.surface,
                   ),
-                ],
-              ),
+              ],
             ),
-            const SizedBox(width: 4),
-            if (isActive)
-              LiveIndicator(
-                spreadRadius: 8,
-                spreadDuration: const Duration(milliseconds: 800),
-                waitDuration: const Duration(seconds: 1),
-                color: colorScheme.surface,
-              ),
-          ],
-        ),
-        trailing: IconButton(
-          icon: Icon(Icons.manage_search, color: isActive ? colorScheme.surface : colorScheme.primary),
-          onPressed: () => SearchStreamingBottomSheet.show(context, title: title, artist: subtitle),
-        ),
+          ),
+          IconButton(
+            icon: Icon(Icons.manage_search, color: isActive ? colorScheme.surface : colorScheme.primary),
+            onPressed: () => SearchStreamingBottomSheet.show(context, title: title, artist: subtitle),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/radio_luz/presentation/radio_luz_view.dart
+++ b/lib/features/radio_luz/presentation/radio_luz_view.dart
@@ -27,7 +27,6 @@ class RadioLuzView extends StatelessWidget {
         body: Stack(
           children: [
             ListView(
-              physics: const BouncingScrollPhysics(),
               padding: const EdgeInsets.symmetric(vertical: RadioLuzConfig.horizontalBasePadding),
               children: [
                 RadioLuzTitle(title: l10n.now_playing.toUpperCase()),


### PR DESCRIPTION
I think it's android related bug. I used ios animation as a temporary solution
[scroll.webm](https://github.com/user-attachments/assets/d74016f2-bd62-4721-969c-0489d8ce0e5a)
#983 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes scrolling issue in `now_playing_section.dart` by replacing `ListTile` with `Container` and `Row`, using iOS animation style for Android bug.
> 
>   - **Behavior**:
>     - Replaces `ListTile` with `Container` and `Row` in `_NowPlayingTile` in `now_playing_section.dart` to fix scrolling issue.
>     - Uses iOS animation style as a temporary solution for Android-specific bug.
>   - **Layout**:
>     - Changes layout structure in `_NowPlayingTile` to use `Container` with `BoxDecoration` and `Row` for content arrangement.
>     - Adjusts padding and spacing for elements within `_NowPlayingTile`.
>   - **Styling**:
>     - Updates color and text style logic based on `isActive` state in `_NowPlayingTile`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 91db38917a210fa8ce673ae86d0ceccb8f950313. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->