### PR TITLE
fix(sks-favs): add bottom padding

### DIFF
--- a/lib/features/sks/sks_favourite_dishes/presentation/sks_favourite_dishes_view.dart
+++ b/lib/features/sks/sks_favourite_dishes/presentation/sks_favourite_dishes_view.dart
@@ -159,6 +159,7 @@ class _SksFavouriteDishesView extends ConsumerWidget {
               ),
           ],
         ),
+        const SliverPadding(padding: EdgeInsets.only(bottom: SksMenuConfig.paddingLarge)),
       ],
     );
   }


### PR DESCRIPTION
<img width="365" height="643" alt="image" src="https://github.com/user-attachments/assets/c09437b7-96f5-4395-b391-7631c6b0c5f2" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds bottom padding to `_SksFavouriteDishesView` in `sks_favourite_dishes_view.dart` for consistent layout spacing.
> 
>   - **Layout**:
>     - Adds `SliverPadding` with `EdgeInsets.only(bottom: SksMenuConfig.paddingLarge)` to `_SksFavouriteDishesView` in `sks_favourite_dishes_view.dart` for consistent bottom spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 084ec73f51e9c71e56b7d7bd62680a0b09290bed. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->