### PR TITLE
fix: multilayer map offline view

### DIFF
--- a/lib/features/bottom_scroll_sheet/data_list.dart
+++ b/lib/features/bottom_scroll_sheet/data_list.dart
@@ -11,15 +11,17 @@ import "../map_view/controllers/controllers_set.dart";
 import "../map_view/widgets/map_config.dart";
 import "data_list_loading.dart";
 
-class DataSliverList<T extends GoogleNavigable> extends ConsumerWidget {
-  const DataSliverList({super.key});
+class DataSliverList<T extends GoogleNavigable> extends HookConsumerWidget {
+  const DataSliverList({super.key, this.uiErrorMessage});
+
+  final String? uiErrorMessage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final itemsState = ref.watch(context.mapDataController<T>());
     return switch (itemsState) {
       AsyncError(:final error, :final stackTrace) => SliverToBoxAdapter(
-        child: MyErrorWidget(error, stackTrace: stackTrace),
+        child: MyErrorWidget(error, stackTrace: stackTrace, uiErrorMessage: uiErrorMessage),
       ),
       AsyncValue(:final value) when value != null => _DataSliverList<T>(value.data),
       _ => const DataListLoading(),

--- a/lib/features/bottom_scroll_sheet/map_data_sheet_list.dart
+++ b/lib/features/bottom_scroll_sheet/map_data_sheet_list.dart
@@ -115,6 +115,10 @@ class MapDataSheetList<T extends GoogleNavigable> extends HookConsumerWidget {
     final areOnlyOneLayerEnabled = tabs.length == 1;
     final isNoTabs = tabs.isEmpty;
 
+    final offlineErrorMessage = context.localize.my_offline_error_message(
+      context.localize.multilayer_map_offline_error,
+    );
+
     useInitialActiveId(
       context.initialActiveItemId<T>(),
       ref.watch(context.activeMarkerController<T>().notifier),
@@ -140,7 +144,7 @@ class MapDataSheetList<T extends GoogleNavigable> extends HookConsumerWidget {
             scrollController: scrollController,
             initialSectionType: context.initialSectionType<T>(),
           ),
-        if (categoryData == null || areOnlyOneLayerEnabled) DataSliverList<T>(),
+        if (categoryData == null || areOnlyOneLayerEnabled) DataSliverList<T>(uiErrorMessage: offlineErrorMessage),
         if (isNoTabs && categoryData != null)
           SliverFillRemaining(child: Center(child: Text(context.localize.no_layers_available))),
         const SliverToBoxAdapter(child: SizedBox(height: SearchBoxAppBar.defaultBottomPadding)),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -611,6 +611,7 @@
   "bicycle_shower_single": "Shower for cyclists",
   "pink_box_single": "Pink box",
   "multilayer_map_title": "Campus map",
+  "multilayer_map_offline_error": "Campus maps",
   "main_branch": "Wrocław University of Science and Technology",
   "jelenia_gora_branch": "Jelenia Góra Branch",
   "walbrzych_branch": "Wałbrzych Branch",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3638,6 +3638,10 @@
   "@multilayer_map_title": {
     "description": "Title for multilayer map title"
   },
+  "multilayer_map_offline_error": "Mapy kampusu",
+  "@multilayer_map_offline_error": {
+    "description": "Offline error for multilayer-map"
+  },
   "main_branch": "Politechnika Wrocławska",
   "@main_branch": {
     "description": "Main branch option in the branch selection dialog"

--- a/lib/widgets/my_error_widget.dart
+++ b/lib/widgets/my_error_widget.dart
@@ -15,10 +15,11 @@ import "../utils/context_extensions.dart";
 import "../utils/unwaited_microtask.dart";
 
 class MyErrorWidget extends HookWidget {
-  const MyErrorWidget(this.error, {required this.stackTrace, super.key});
+  const MyErrorWidget(this.error, {required this.stackTrace, super.key, this.uiErrorMessage});
 
   final Object? error;
   final StackTrace? stackTrace;
+  final String? uiErrorMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +34,7 @@ class MyErrorWidget extends HookWidget {
     return switch (error) {
       ParkingsOfflineException() => const OfflineParkingsView(),
       RestFrameworkOfflineException(:final localizedMessage, :final onRetry) => OfflineMessage(
-        localizedMessage(context),
+        uiErrorMessage ?? localizedMessage(context),
         onRefresh: onRetry,
       ),
       _ => Center(


### PR DESCRIPTION
Fixed multilayer offline map view

https://github.com/user-attachments/assets/23460c68-29db-43d6-bb5f-44073d8ace9a


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix multilayer map offline view by adding custom error messages and updating localization.
> 
>   - **Behavior**:
>     - Adds `uiErrorMessage` parameter to `DataSliverList` in `data_list.dart` to display custom error messages.
>     - Updates `MapDataSheetList` in `map_data_sheet_list.dart` to pass `offlineErrorMessage` to `DataSliverList` when only one layer is enabled or no category data is available.
>     - Modifies `MyErrorWidget` in `my_error_widget.dart` to use `uiErrorMessage` if provided, otherwise defaults to localized message.
>   - **Localization**:
>     - Adds `multilayer_map_offline_error` string to `app_en.arb` and `app_pl.arb` for offline error messaging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 1db3eae4998520d414afd40383e1b4eeb2e89fe1. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->