### PR TITLE
fix: offline english screens

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -138,7 +138,7 @@ dependencies:
   sentry_flutter: ^9.9.1
 
   #Solvro packages
-  solvro_translator_with_drift_cache_flutter: ^0.8.0
+  solvro_translator_with_drift_cache_flutter: ^0.8.1
   solvro_translator_core: ^0.8.0
   clarity_flutter: ^1.6.0
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds offline exception handling in `translate.dart` and updates `solvro_translator_with_drift_cache_flutter` to `^0.8.1`.
> 
>   - **Behavior**:
>     - Adds exception handling for `SolvroTranslationOfflineException` in `getAndCacheDataWithTranslation()` in `translate.dart`, throwing `RestFrameworkOfflineException` with a localized message and retry option.
>   - **Dependencies**:
>     - Updates `solvro_translator_with_drift_cache_flutter` version to `^0.8.1` in `pubspec.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 16636e6502fac23dcddfe89d0e0c00026d1e1c27. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->