### PR TITLE
fix(sks-favs): offline view

### DIFF
--- a/lib/features/sks/sks_favourite_dishes/data/repository/sks_favourite_dishes_repository.dart
+++ b/lib/features/sks/sks_favourite_dishes/data/repository/sks_favourite_dishes_repository.dart
@@ -38,9 +38,14 @@ class SksFavouriteDishesRepository extends _$SksFavouriteDishesRepository {
           .castAsObject,
       if (deviceKey != null)
         ref
-            .read(restClientProvider)
-            .get<Map<String, dynamic>>(_api + _subscriptionsEndpoint + deviceKey)
-            .then((val) => SksFavouriteDishesResponse.fromJson(val.data!)),
+            .getAndCacheDataWithTranslation(
+              _api + _subscriptionsEndpoint + deviceKey,
+              SksFavouriteDishesResponse.fromJson,
+              extraValidityCheck: (_) => false, // always invalidate the cache
+              localizedOfflineMessage: SksFavouriteDishesView.localizedOfflineMessage,
+              onRetry: ref.invalidateSelf,
+            )
+            .castAsObject,
     ]);
 
     final recentDishes = responses[0];


### PR DESCRIPTION
Offline view didn't show up because subscriptions fetch was not using custom safe get.

Decided to use getAndCacheDataWithTranslation function to ensure translations and keep implementation consistent with pretty much every other repository in the project. However, because subscriptions of the user can change whenever, cache should always be invalidated.

https://github.com/user-attachments/assets/3ccd3175-2fa1-4cdc-9ff5-a38ff38c460b



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `getAndCacheDataWithTranslation` for subscription data in `SksFavouriteDishesRepository`, ensuring translations and always invalidating cache.
> 
>   - **Behavior**:
>     - Use `getAndCacheDataWithTranslation` for fetching subscription data in `SksFavouriteDishesRepository` to ensure translations and consistency.
>     - Cache for subscription data is always invalidated to handle dynamic changes.
>   - **Misc**:
>     - Removed use of custom safe get for fetching subscriptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for f31746e2923796baad3d21a1eba3689dd23ebd49. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->