### PR TITLE
refactor(sks-favs): proper provider for device id retrieval

### DIFF
--- a/lib/features/sks/sks_favourite_dishes/data/repository/sks_favourite_dishes_repository.dart
+++ b/lib/features/sks/sks_favourite_dishes/data/repository/sks_favourite_dishes_repository.dart
@@ -2,7 +2,6 @@ import "package:dio/dio.dart";
 import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
-import "../../../../../api_base_rest/client/dio_client.dart";
 import "../../../../../api_base_rest/client/json.dart";
 import "../../../../../api_base_rest/translations/translate.dart";
 import "../../../../../config/env.dart";
@@ -24,7 +23,7 @@ class SksFavouriteDishesRepository extends _$SksFavouriteDishesRepository {
 
   @override
   Future<({IList<SksMenuDishMinimal> subscribed, IList<SksMenuDishMinimal> unsubscribed})> build() async {
-    final deviceKey = await getDeviceId();
+    final deviceKey = await ref.watch(getDeviceIdProvider.future);
     final responses = await Future.wait([
       ref
           .getAndCacheDataWithTranslation(
@@ -58,9 +57,8 @@ class SksFavouriteDishesRepository extends _$SksFavouriteDishesRepository {
   }
 
   Future<bool> toggleDishSubscription(String dishId, {required bool isSubscribed}) async {
-    final restClient = ref.read(restClientProvider);
     try {
-      await restClient.toggleSubscription(dishId, isSubscribed: isSubscribed);
+      await ref.toggleSubscription(dishId, isSubscribed: isSubscribed);
     } on DioException catch (_) {
       return false;
     }

--- a/lib/features/sks/sks_favourite_dishes/utils/sks_favourite_dishes_extension.dart
+++ b/lib/features/sks/sks_favourite_dishes/utils/sks_favourite_dishes_extension.dart
@@ -1,12 +1,15 @@
 import "package:dio/dio.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
 
+import "../../../../api_base_rest/client/dio_client.dart";
 import "../../../../config/env.dart";
 import "../../../../utils/get_device_id.dart";
 
-extension DioFetchSksFavouriteDishes on Dio {
+extension DioFetchSksFavouriteDishes on Ref {
   Future<void> toggleSubscription(String dishId, {required bool isSubscribed}) async {
+    final dio = read(restClientProvider);
     final url = "${Env.sksUrl}/subscriptions/toggle";
-    final key = await getDeviceId();
+    final key = await watch(getDeviceIdProvider.future);
     if (key == null) {
       throw DioException(
         requestOptions: RequestOptions(path: url),
@@ -14,7 +17,7 @@ extension DioFetchSksFavouriteDishes on Dio {
       );
     }
     final dishIdNum = int.tryParse(dishId);
-    await post<Map<String, dynamic>>(
+    await dio.post<Map<String, dynamic>>(
       url,
       data: {"deviceKey": key, "mealId": dishIdNum ?? dishId, "subscribe": isSubscribed},
     );

--- a/lib/utils/get_device_id.dart
+++ b/lib/utils/get_device_id.dart
@@ -5,8 +5,10 @@ import "package:crypto/crypto.dart";
 import "package:device_info_plus/device_info_plus.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
+part "get_device_id.g.dart";
+
 @Riverpod(keepAlive: true)
-Future<String?> getDeviceId() async {
+Future<String?> getDeviceId(Ref ref) async {
   String? deviceId;
   if (Platform.isIOS) {
     final iosDeviceInfo = await DeviceInfoPlugin().iosInfo;

--- a/lib/utils/ref_extensions.dart
+++ b/lib/utils/ref_extensions.dart
@@ -26,7 +26,7 @@ extension RefRegisterForNotificationsX on Ref {
   Future<({String? deviceKey})> registerForNotifications() async {
     final client = read(restClientProvider);
     final url = "${Env.sksUrl}/device/registration-token";
-    final deviceKey = await getDeviceId();
+    final deviceKey = await watch(getDeviceIdProvider.future);
     final registrationToken = await _getTokenSafe();
     if (deviceKey == null || registrationToken == null) {
       return (deviceKey: deviceKey);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor device ID retrieval to use a provider across multiple files for consistency and maintainability.
> 
>   - **Device ID Retrieval**:
>     - Refactor `getDeviceId` to use `getDeviceIdProvider` in `get_device_id.dart`.
>     - Update `build()` in `sks_favourite_dishes_repository.dart` to use `ref.watch(getDeviceIdProvider.future)`.
>     - Modify `toggleSubscription()` in `sks_favourite_dishes_extension.dart` to use `watch(getDeviceIdProvider.future)`.
>     - Change `registerForNotifications()` in `ref_extensions.dart` to use `watch(getDeviceIdProvider.future)`.
>   - **Misc**:
>     - Remove unused import of `dio_client.dart` in `sks_favourite_dishes_repository.dart`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 9022901dcc720088e0699dc6100c5df3a2b0062c. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->