### PR TITLE
feat(radio-luz): audio icon

### DIFF
--- a/lib/features/radio_luz/presentation/audio_player_widget.dart
+++ b/lib/features/radio_luz/presentation/audio_player_widget.dart
@@ -38,6 +38,13 @@ class AudioPlayerWidget extends HookConsumerWidget {
             child: Row(
               spacing: RadioLuzConfig.spacingMedium,
               children: [
+                IconButton(
+                  onPressed: radioController.toggleVolume,
+                  icon: Icon(
+                    radioState.isMuted ? Icons.volume_off : Icons.volume_up,
+                    color: context.colorScheme.onPrimaryContainer,
+                  ),
+                ),
                 RadioPlayerSlider(radioController: radioController, volume: radioState.volume),
                 const RadioPlayerInfo(),
                 RadioPlayerControlButton(

--- a/lib/features/radio_luz/presentation/radio_player_slider.dart
+++ b/lib/features/radio_luz/presentation/radio_player_slider.dart
@@ -25,6 +25,7 @@ class RadioPlayerSlider extends StatelessWidget {
         ),
         child: Slider(
           value: volume,
+          onChangeEnd: radioController.rememberVolume,
           onChanged: (newVolume) async {
             await radioController.setVolume(newVolume);
           },

--- a/lib/features/radio_luz/service/radio_player_controller.dart
+++ b/lib/features/radio_luz/service/radio_player_controller.dart
@@ -25,6 +25,8 @@ class RadioController extends _$RadioController {
   _AppLifecycleStopper? _stopper;
 
   var _initialized = false;
+  var _prevVolume = 1.0;
+  final _muteThreshold = 0.05;
 
   @override
   RadioState build() {
@@ -47,7 +49,7 @@ class RadioController extends _$RadioController {
       unawaited(_initPlayer());
     }
 
-    return RadioState(isPlaying: isPlaying, isLoading: isLoading, volume: volume);
+    return RadioState(isPlaying: isPlaying, isLoading: isLoading, volume: volume, isMuted: volume <= _muteThreshold);
   }
 
   Future<void> _initPlayer() async {
@@ -102,6 +104,18 @@ class RadioController extends _$RadioController {
 
   Future<void> setVolume(double newVolume) async {
     await _player.setVolume(newVolume);
+  }
+
+  void rememberVolume(double newVolume) {
+    _prevVolume = newVolume > _muteThreshold ? newVolume : _prevVolume;
+  }
+
+  Future<void> toggleVolume() async {
+    if (state.volume <= _muteThreshold) {
+      await _player.setVolume(_prevVolume);
+    } else {
+      await _player.setVolume(0);
+    }
   }
 }
 

--- a/lib/features/radio_luz/service/radio_state.dart
+++ b/lib/features/radio_luz/service/radio_state.dart
@@ -8,5 +8,6 @@ abstract class RadioState with _$RadioState {
     @Default(false) bool isPlaying,
     @Default(false) bool isLoading,
     @Default(1.0) double volume,
+    @Default(false) bool isMuted,
   }) = _RadioState;
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/6d251fca-07e5-4afd-a0b1-d91abec24ecb

I also accidentally documented a bug: the playing dot being in the middle instead of the right end of the tile.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds audio icon for volume toggle and remembers previous volume in `radio-luz` player, updates `RadioState` with `isMuted`, and documents a UI bug.
> 
>   - **Behavior**:
>     - Adds `IconButton` in `audio_player_widget.dart` to toggle volume using `radioController.toggleVolume`.
>     - Updates `RadioPlayerSlider` in `radio_player_slider.dart` to call `radioController.rememberVolume` on volume change end.
>     - `RadioController` in `radio_player_controller.dart` now tracks `_prevVolume` and `_muteThreshold` to manage volume state.
>     - `toggleVolume()` in `RadioController` toggles between mute and previous volume.
>   - **State Management**:
>     - Adds `isMuted` property to `RadioState` in `radio_state.dart` to track mute status.
>   - **Misc**:
>     - Documents a bug: playing dot is incorrectly positioned in the middle instead of the right end of the tile.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 245adcbaf972c002b8f1404e79995e5d4253b66e. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->