### PR TITLE
fix: countdown text overflow

### DIFF
--- a/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
+++ b/lib/features/academic_calendar/widgets/countdown_widget/exam_session_countdown.dart
@@ -69,6 +69,7 @@ class ExamSessionCountdown extends ConsumerWidget {
                         academicCalendar.localizeDaysCounterMessage(context),
                         style: context.textTheme.bodyLarge?.copyWith(color: context.colorScheme.surface),
                         textScaler: const TextScaler.linear(0.97),
+                        maxLines: 2,
                       ),
                     ),
                   ],


### PR DESCRIPTION

<img width="355" height="95" alt="image" src="https://github.com/user-attachments/assets/5d5ec28d-5d78-48ca-be94-fc24c999c744" />

I restricted the number of lines to 2, as I had idea how to display the whole text on screens with narrow resolutions. Do you have another idea to approach the issue @odominiak ?



<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `maxLines: 2` to `Text` widget in `ExamSessionCountdown` to prevent text overflow.
> 
>   - **UI Fix**:
>     - Add `maxLines: 2` to `Text` widget in `ExamSessionCountdown` to prevent text overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for 5f1508adbac4bd35bf21f883c73c2e06861dc173. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->