### PR TITLE
refactor: do not use should render

### DIFF
--- a/lib/features/planner_advert/data/models/planner_banner_models.dart
+++ b/lib/features/planner_advert/data/models/planner_banner_models.dart
@@ -31,7 +31,6 @@ abstract class PlannerBanner with _$PlannerBanner {
     DateTime? visibleUntil,
     required DateTime createdAt,
     required DateTime updatedAt,
-    @Default(false) bool shouldRender,
   }) = _PlannerBanner;
 
   factory PlannerBanner.fromJson(Map<String, dynamic> json) => _$PlannerBannerFromJson(json);

--- a/lib/features/planner_advert/repository/planner_advert_repository.dart
+++ b/lib/features/planner_advert/repository/planner_advert_repository.dart
@@ -22,10 +22,18 @@ Future<PlannerBanner?> plannerAdvertContentRepository(Ref ref) async {
       )
       .castAsObject;
 
-  final active = response.data.where((b) => b.shouldRender && !b.draft).toList()
-    ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+  final now = DateTime.now();
+  final active =
+      response.data
+          .where(
+            (b) =>
+                !b.draft &&
+                (b.visibleFrom == null || b.visibleFrom!.isBefore(now)) &&
+                (b.visibleUntil == null || b.visibleUntil!.isAfter(now)),
+          )
+          .toList()
+        ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
 
   final banner = active.isNotEmpty ? active.first : null;
-
   return banner;
 }

--- a/lib/features/planner_advert/widgets/planer_ad_badge.dart
+++ b/lib/features/planner_advert/widgets/planer_ad_badge.dart
@@ -35,7 +35,6 @@ class _BadgeContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!data.shouldRender) return const SizedBox.shrink();
     final textColor = data.textColor != null ? HexColor(data.textColor!) : context.colorScheme.onTertiary;
     final backgroundColor = data.backgroundColor != null ? HexColor(data.backgroundColor!) : null;
     return Padding(

--- a/lib/features/planner_advert/widgets/planner_advert_widget.dart
+++ b/lib/features/planner_advert/widgets/planner_advert_widget.dart
@@ -42,27 +42,25 @@ class _PlannerAdvertBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return !data.shouldRender
-        ? const SizedBox.shrink()
-        : Padding(
-            padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingSmall),
-            child: TechnicalMessage(
-              padding: const EdgeInsets.all(HomeViewConfig.paddingMedium).copyWith(bottom: 0),
-              title: data.title,
-              titleColor: data.titleColor != null ? HexColor(data.titleColor!) : null,
-              message: data.description,
-              alertType: AlertType.info,
-              icon: data.url != null ? Icon(Icons.open_in_new_rounded, color: context.colorScheme.surface) : null,
-              onTap: data.url != null
-                  ? () {
-                      unawaited(ref.trackEvent(ClarityEvents.goToBannerExternalLink));
-                      unawaited(ref.launch(data.url!));
-                    }
-                  : null,
-              backgoundColor: data.backgroundColor != null ? HexColor(data.backgroundColor!) : null,
-              textColor: data.textColor != null ? HexColor(data.textColor!) : null,
-              translate: true,
-            ),
-          );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: HomeViewConfig.paddingSmall),
+      child: TechnicalMessage(
+        padding: const EdgeInsets.all(HomeViewConfig.paddingMedium).copyWith(bottom: 0),
+        title: data.title,
+        titleColor: data.titleColor != null ? HexColor(data.titleColor!) : null,
+        message: data.description,
+        alertType: AlertType.info,
+        icon: data.url != null ? Icon(Icons.open_in_new_rounded, color: context.colorScheme.surface) : null,
+        onTap: data.url != null
+            ? () {
+                unawaited(ref.trackEvent(ClarityEvents.goToBannerExternalLink));
+                unawaited(ref.launch(data.url!));
+              }
+            : null,
+        backgoundColor: data.backgroundColor != null ? HexColor(data.backgroundColor!) : null,
+        textColor: data.textColor != null ? HexColor(data.textColor!) : null,
+        translate: true,
+      ),
+    );
   }
 }


### PR DESCRIPTION
Now rendering banner only depends on dates and !draft. The checks in the widget and badge have been removed completely because only a banner that should be rendered can be returned from a provider (otherwise provider returns null), so additional check in the UI is redundant.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor banner rendering logic by removing `shouldRender` checks and relying on date and draft status.
> 
>   - **Behavior**:
>     - Remove `shouldRender` property from `PlannerBanner` in `planner_banner_models.dart`.
>     - Update `plannerAdvertContentRepository` in `planner_advert_repository.dart` to filter banners based on date and draft status only.
>     - Remove `shouldRender` checks from `_BadgeContent` in `planer_ad_badge.dart` and `_PlannerAdvertBanner` in `planner_advert_widget.dart`.
>   - **Misc**:
>     - Simplify banner rendering logic by relying on provider to return only renderable banners.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fmobile-topwr&utm_source=github&utm_medium=referral)<sup> for f2863d97b47b64e0fc553bf2a30d858257916458. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->