### PR TITLE
feat(digital-guide): paralax effect

### DIFF
--- a/lib/features/digital_guide/presentation/digital_guide_view.dart
+++ b/lib/features/digital_guide/presentation/digital_guide_view.dart
@@ -119,6 +119,7 @@ class _DigitalGuideView extends ConsumerWidget {
           SliverAppBar(
             excludeHeaderSemantics: true,
             expandedHeight: DetailViewsConfig.imageHeight,
+            automaticallyImplyLeading: false,
             flexibleSpace: SizedBox(
               height: DetailViewsConfig.imageHeight,
               child: Focus(autofocus: true, child: ZoomableCachedImage(photoUrl)),


### PR DESCRIPTION
# Demo
https://github.com/user-attachments/assets/5ea86ca9-3306-473b-b603-71c2c9b7d204

# Issue
The A1 building image that we fetch from the outer API has a weird gray stripe on the left side.
<img width="335" height="262" alt="image" src="https://github.com/user-attachments/assets/35728eb6-1d45-4b0b-8c02-5290ef645dfd" />
<img width="357" height="333" alt="image" src="https://github.com/user-attachments/assets/b365ce55-e0d4-4dc4-8b36-d205fed0777e" />
This issue regards only the A1 building
Idk whether we have control over it

# Task to consider
@odominiak 
I would personally remove the back button from the upper left corner, as we have it in the app bar. 
<img width="340" height="155" alt="image" src="https://github.com/user-attachments/assets/94539fbe-e2e3-4e95-a12d-93f913e00e6e" />
