### PR TITLE
fix: Adjust pop navigation button appearance

### DIFF
--- a/lib/widgets/detail_views/pop_button.dart
+++ b/lib/widgets/detail_views/pop_button.dart
@@ -17,7 +17,7 @@ class DetailViewPopButton extends ConsumerWidget {
       onPressed: () {
         Navigator.pop(context);
       },
-      style: TextButton.styleFrom(padding: const EdgeInsets.all(12)),
+      style: TextButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 2)),
 
       child: Semantics(
         label: title != null
@@ -35,7 +35,7 @@ class DetailViewPopButton extends ConsumerWidget {
                   title,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
+                  textAlign: TextAlign.left,
                   style: context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.primary),
                 ),
               ),


### PR DESCRIPTION
Reduce horizontal padding to fit text and align it to the left:
<img width="461" height="818" alt="obraz" src="https://github.com/user-attachments/assets/d00f0690-286e-4c5c-81bd-987dfc7c8e05" />
<img width="461" height="818" alt="obraz" src="https://github.com/user-attachments/assets/94b7e682-e7db-4fad-8225-337183aeacd7" />
