### PR TITLE
fix(parkings): adjust padding for people counter based on active state

### DIFF
--- a/lib/features/parkings/parkings_view/widgets/parking_wide_tile_card.dart
+++ b/lib/features/parkings/parkings_view/widgets/parking_wide_tile_card.dart
@@ -124,7 +124,7 @@ class _RightColumn extends StatelessWidget {
       children: [
         const Spacer(),
         Padding(
-          padding: ParkingsConfig.peopleCounterBottomPadding,
+          padding: isActive ? ParkingsConfig.peopleCounterBottomPadding : EdgeInsets.zero,
           child: Semantics(
             label:
                 "${context.localize.parking_people_live_screen_reader_label} ${parking.parsedNumberOfPlaces} ${context.localize.sks_people_live_screen_reader_label_trend}${localizedName(parking.trend, context)}",


### PR DESCRIPTION
change padding based on wide tile state:
<img width="461" height="818" alt="obraz" src="https://github.com/user-attachments/assets/9ced1fba-a7f6-40bc-ad8a-b30cfb01995c" />
<img width="461" height="818" alt="obraz" src="https://github.com/user-attachments/assets/9695dbc9-913c-426f-9a3e-9fe752807850" />
