### PR TITLE
fix(calendar): remove slashes from events location

### DIFF
--- a/lib/features/calendar/bussiness/get_events_per_days_use_case.dart
+++ b/lib/features/calendar/bussiness/get_events_per_days_use_case.dart
@@ -82,12 +82,21 @@ SingleCalendarItem _createCalendarItem(
 
   // Sometimes the location text comes with escape sequences
   // that arent handled correctly
-  final cleanLocation = (event.location ?? "")
-      .replaceAll(r"\\", r"\")
-      .replaceAll(r"\;", ";")
-      .replaceAll(r"\,", ",")
-      .replaceAll(r"\N", "\n")
-      .replaceAll(r"\n", "\n");
+  final cleanLocation = (event.location ?? "").replaceAllMapped(RegExp(r"\\([\\;,nN])"), (match) {
+    switch (match.group(1)) {
+      case r"\":
+        return r"\";
+      case ";":
+        return ";";
+      case ",":
+        return ",";
+      case "n":
+      case "N":
+        return "\n";
+      default:
+        return match.group(0)!;
+    }
+  });
 
   return (
     name: event.name,

--- a/lib/features/calendar/bussiness/get_events_per_days_use_case.dart
+++ b/lib/features/calendar/bussiness/get_events_per_days_use_case.dart
@@ -80,9 +80,18 @@ SingleCalendarItem _createCalendarItem(
 
   final hoursString = isSingleDay ? _formatTimeRange(startDate, endDate) : "${l10n.day} $dayNumber/$totalDays";
 
+  // Sometimes the location text comes with escape sequences
+  // that arent handled correctly
+  final cleanLocation = (event.location ?? "")
+      .replaceAll(r"\\", r"\")
+      .replaceAll(r"\;", ";")
+      .replaceAll(r"\,", ",")
+      .replaceAll(r"\N", "\n")
+      .replaceAll(r"\n", "\n");
+
   return (
     name: event.name,
-    location: event.location ?? "",
+    location: cleanLocation,
     hoursString: hoursString,
     description: event.description,
     accentColor: event.accentColor != null ? HexColor(event.accentColor!) : null,

--- a/lib/features/calendar/presentation/widgets/calendar_tile.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_tile.dart
@@ -20,12 +20,12 @@ class CalendarTile extends ConsumerWidget {
                   text: item.hoursString,
                   style: TextStyle(fontWeight: item.hoursString.trim().contains("-") ? FontWeight.bold : null),
                 ),
-                if (item.location.trim().isNotEmpty) TextSpan(text: "\n${item.location}"),
+                if (item.location.trim().isNotEmpty) TextSpan(text: "\n${item.location.replaceAll(r'\,', ',')}"),
               ],
             ),
           )
         : item.location.trim().isNotEmpty
-        ? Text(item.location)
+        ? Text(item.location.replaceAll(r"\,", ","))
         : null;
 
     return Card(

--- a/lib/features/calendar/presentation/widgets/calendar_tile.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_tile.dart
@@ -20,12 +20,12 @@ class CalendarTile extends ConsumerWidget {
                   text: item.hoursString,
                   style: TextStyle(fontWeight: item.hoursString.trim().contains("-") ? FontWeight.bold : null),
                 ),
-                if (item.location.trim().isNotEmpty) TextSpan(text: "\n${item.location.replaceAll(r'\,', ',')}"),
+                if (item.location.trim().isNotEmpty) TextSpan(text: "\n${item.location}"),
               ],
             ),
           )
         : item.location.trim().isNotEmpty
-        ? Text(item.location.replaceAll(r"\,", ","))
+        ? Text(item.location)
         : null;
 
     return Card(

--- a/test/features/calendar/bussiness/group_events_by_year_test.dart
+++ b/test/features/calendar/bussiness/group_events_by_year_test.dart
@@ -251,7 +251,7 @@ void main() {
         endTime: "2026-06-15T14:40:00",
         location: r"Budynek D-21\, pokój A\nBudynek A-2 \\ Budynek C-4 \; \N Aleja Profesorów",
         description: null,
-        accentColor: null
+        accentColor: null,
       );
 
       final events = [event].toIList();

--- a/test/features/calendar/bussiness/group_events_by_year_test.dart
+++ b/test/features/calendar/bussiness/group_events_by_year_test.dart
@@ -244,20 +244,41 @@ void main() {
     });
 
     test("should handle escape sequences in location correctly", () {
-      const event = CalendarData(
+      const event1 = CalendarData(
         id: 42,
-        name: "Event",
+        name: "Event 1",
         startTime: "2026-06-14T10:30:00",
         endTime: "2026-06-15T14:40:00",
-        location: r"Budynek D-21\, pokój A\nBudynek A-2 \\ Budynek C-4 \; \N Aleja Profesorów",
+        location: r"Budynek D-21\, pokój A\nBudynek A-2 \\ Budynek C-4 \; \N Aleja Profesorów\\, Aula \\; SKS",
         description: null,
         accentColor: null,
       );
 
-      final events = [event].toIList();
-      final result = groupEventsByYear(events, l10n);
-      final calendarItem = result.first.events.first.events.first.events.first;
-      expect(calendarItem.location, "Budynek D-21, pokój A\nBudynek A-2 \\ Budynek C-4 ; \n Aleja Profesorów");
+      const event2 = CalendarData(
+        id: 42,
+        name: "Event 2",
+        startTime: "2026-06-16T10:30:00",
+        endTime: "2026-06-17T14:40:00",
+        location: r"\\, Aula \\; SKS \\n A-4",
+        description: null,
+        accentColor: null,
+      );
+
+      final events = [event1, event2].toIList();
+      final results = groupEventsByYear(events, l10n);
+
+      final calendarItem1 = results.first.events.first.events.first.events.first;
+      final calendarItem2 = results.first.events.first.events[2].events.first;
+
+      const correctString1 =
+          "Budynek D-21, pokój A\n"
+          "Budynek A-2 \\ Budynek C-4 ; \n"
+          r" Aleja Profesorów\, Aula \; SKS";
+
+      const correctString2 = r"\, Aula \; SKS \n A-4";
+
+      expect(calendarItem1.location, correctString1);
+      expect(calendarItem2.location, correctString2);
     });
 
     test("should handle multiple events on the same day", () {

--- a/test/features/calendar/bussiness/group_events_by_year_test.dart
+++ b/test/features/calendar/bussiness/group_events_by_year_test.dart
@@ -243,6 +243,23 @@ void main() {
       expect(calendarItem.accentColor!.hexString, "#E43D32");
     });
 
+    test("should handle escape sequences in location correctly", () {
+      const event = CalendarData(
+        id: 42,
+        name: "Event",
+        startTime: "2026-06-14T10:30:00",
+        endTime: "2026-06-15T14:40:00",
+        location: r"Budynek D-21\, pokój A\nBudynek A-2 \\ Budynek C-4 \; \N Aleja Profesorów",
+        description: null,
+        accentColor: null
+      );
+
+      final events = [event].toIList();
+      final result = groupEventsByYear(events, l10n);
+      final calendarItem = result.first.events.first.events.first.events.first;
+      expect(calendarItem.location, "Budynek D-21, pokój A\nBudynek A-2 \\ Budynek C-4 ; \n Aleja Profesorów");
+    });
+
     test("should handle multiple events on the same day", () {
       const event1 = CalendarData(
         id: 1,


### PR DESCRIPTION
These backslashes come from parsing ICS files. My solution only fixes the visible text in the calendar view. If changes in the global scope are preferable, editing the model file or handling it during backend parsing would be a better option.