### PR TITLE
fix(radio-luz): adjust spacing and padding in audio player widget

### DIFF
--- a/lib/config/ui_config.dart
+++ b/lib/config/ui_config.dart
@@ -270,7 +270,7 @@ abstract class DigitalGuideConfig {
 
 abstract class RadioLuzConfig {
   static const spacingSmall = 4.0;
-  static const spacingMedium = 8.0;
+  static const spacingMedium = 12.0;
   static const paddingSmall = 8.0;
   static const horizontalBasePadding = 16.0;
 }

--- a/lib/features/radio_luz/presentation/audio_player_widget.dart
+++ b/lib/features/radio_luz/presentation/audio_player_widget.dart
@@ -34,18 +34,22 @@ class AudioPlayerWidget extends HookConsumerWidget {
           width: double.infinity,
           height: 59,
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
+            padding: EdgeInsets.symmetric(horizontal: 16 / MediaQuery.textScalerOf(context).scale(2), vertical: 2),
             child: Row(
               spacing: RadioLuzConfig.spacingMedium,
               children: [
-                IconButton(
-                  onPressed: radioController.toggleVolume,
-                  icon: Icon(
-                    radioState.isMuted ? Icons.volume_off : Icons.volume_up,
-                    color: context.colorScheme.onPrimaryContainer,
-                  ),
+                Row(
+                  children: [
+                    IconButton(
+                      onPressed: radioController.toggleVolume,
+                      icon: Icon(
+                        radioState.isMuted ? Icons.volume_off : Icons.volume_up,
+                        color: context.colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                    RadioPlayerSlider(radioController: radioController, volume: radioState.volume),
+                  ],
                 ),
-                RadioPlayerSlider(radioController: radioController, volume: radioState.volume),
                 const RadioPlayerInfo(),
                 RadioPlayerControlButton(
                   radioController: radioController,


### PR DESCRIPTION
<img width="461" height="818" alt="Screenshot From 2026-05-24 21-13-07" src="https://github.com/user-attachments/assets/d6ffa9d9-d583-4948-ac68-03bbb125ad1e" />
<img width="461" height="818" alt="Screenshot From 2026-05-24 21-11-50" src="https://github.com/user-attachments/assets/2d57bb02-e39f-4a68-8ae3-9db3da9d39ff" />
