### PR TITLE
feat(activity-days): add Timetable view

### DIFF
--- a/lib/features/activity_days/business/activity_days_timetable_use_case.dart
+++ b/lib/features/activity_days/business/activity_days_timetable_use_case.dart
@@ -25,10 +25,7 @@ Future<IList<TimetableDay>> activityDaysTimetableUseCase(Ref ref) async {
       .map(
         (dayEntry) => (
           date: dayEntry.key,
-          events: dayEntry.value
-              .sorted((a, b) => a.startTime.compareTo(b.startTime))
-              .map(_toCalendarItem)
-              .toIList(),
+          events: dayEntry.value.sorted((a, b) => a.startTime.compareTo(b.startTime)).map(_toCalendarItem).toIList(),
         ),
       )
       .sorted((a, b) => a.date.compareTo(b.date))

--- a/lib/features/activity_days/business/activity_days_timetable_use_case.dart
+++ b/lib/features/activity_days/business/activity_days_timetable_use_case.dart
@@ -44,5 +44,5 @@ SingleCalendarItem _toCalendarItem(ActivityDaysTimetableEntry entry) {
 
 String _formatHours(DateTime start, DateTime? end) {
   String hm(DateTime time) => "${time.hour.toString().padLeft(2, "0")}:${time.minute.toString().padLeft(2, "0")}";
-  return end != null ? "${hm(start)} – ${hm(end)}" : hm(start);
+  return end != null ? "${hm(start)} - ${hm(end)}" : hm(start);
 }

--- a/lib/features/activity_days/business/activity_days_timetable_use_case.dart
+++ b/lib/features/activity_days/business/activity_days_timetable_use_case.dart
@@ -1,0 +1,51 @@
+import "package:collection/collection.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../calendar/bussiness/models.dart";
+import "../data/models/activity_days_response.dart";
+import "../data/repository/activity_days_repository.dart";
+
+part "activity_days_timetable_use_case.g.dart";
+
+typedef TimetableDay = ({DateTime date, IList<SingleCalendarItem> events});
+
+@riverpod
+Future<IList<TimetableDay>> activityDaysTimetableUseCase(Ref ref) async {
+  final event = await ref.watch(activityDaysRepositoryProvider.future);
+  final entries = event?.timetable?.entries ?? const IListConst([]);
+  if (entries.isEmpty) return const IListConst([]);
+
+  final grouped = groupBy(
+    entries.unlock,
+    (ActivityDaysTimetableEntry entry) => DateTime(entry.startTime.year, entry.startTime.month, entry.startTime.day),
+  );
+
+  return grouped.entries
+      .map(
+        (dayEntry) => (
+          date: dayEntry.key,
+          events: dayEntry.value
+              .sorted((a, b) => a.startTime.compareTo(b.startTime))
+              .map(_toCalendarItem)
+              .toIList(),
+        ),
+      )
+      .sorted((a, b) => a.date.compareTo(b.date))
+      .toIList();
+}
+
+SingleCalendarItem _toCalendarItem(ActivityDaysTimetableEntry entry) {
+  return (
+    name: entry.name,
+    location: "",
+    hoursString: _formatHours(entry.startTime, entry.endTime),
+    description: null,
+    accentColor: null,
+  );
+}
+
+String _formatHours(DateTime start, DateTime? end) {
+  String hm(DateTime time) => "${time.hour.toString().padLeft(2, "0")}:${time.minute.toString().padLeft(2, "0")}";
+  return end != null ? "${hm(start)} – ${hm(end)}" : hm(start);
+}

--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -5,6 +5,13 @@ part "activity_days_response.freezed.dart";
 part "activity_days_response.g.dart";
 
 @freezed
+abstract class ActivityDaysListResponse with _$ActivityDaysListResponse {
+  const factory ActivityDaysListResponse(IList<ActivityDaysResponse> data) = _ActivityDaysListResponse;
+
+  factory ActivityDaysListResponse.fromJson(Map<String, dynamic> json) => _$ActivityDaysListResponseFromJson(json);
+}
+
+@freezed
 abstract class ActivityDaysResponse with _$ActivityDaysResponse {
   const factory ActivityDaysResponse({
     required int id,
@@ -24,9 +31,26 @@ abstract class ActivityDaysResponse with _$ActivityDaysResponse {
 
 @freezed
 abstract class ActivityDaysTimetable with _$ActivityDaysTimetable {
-  const factory ActivityDaysTimetable({required int id, String? description}) = _ActivityDaysTimetable;
+  const factory ActivityDaysTimetable({
+    required int id,
+    String? description,
+    @Default(IListConst([])) IList<ActivityDaysTimetableEntry> entries,
+  }) = _ActivityDaysTimetable;
 
   factory ActivityDaysTimetable.fromJson(Map<String, dynamic> json) => _$ActivityDaysTimetableFromJson(json);
+}
+
+@freezed
+abstract class ActivityDaysTimetableEntry with _$ActivityDaysTimetableEntry {
+  const factory ActivityDaysTimetableEntry({
+    required int id,
+    required String name,
+    required DateTime startTime,
+    DateTime? endTime,
+  }) = _ActivityDaysTimetableEntry;
+
+  factory ActivityDaysTimetableEntry.fromJson(Map<String, dynamic> json) =>
+      _$ActivityDaysTimetableEntryFromJson(json);
 }
 
 @freezed

--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -49,8 +49,7 @@ abstract class ActivityDaysTimetableEntry with _$ActivityDaysTimetableEntry {
     DateTime? endTime,
   }) = _ActivityDaysTimetableEntry;
 
-  factory ActivityDaysTimetableEntry.fromJson(Map<String, dynamic> json) =>
-      _$ActivityDaysTimetableEntryFromJson(json);
+  factory ActivityDaysTimetableEntry.fromJson(Map<String, dynamic> json) => _$ActivityDaysTimetableEntryFromJson(json);
 }
 
 @freezed

--- a/lib/features/activity_days/data/repository/activity_days_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_repository.dart
@@ -21,7 +21,30 @@ Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
       endsAt: now.add(const Duration(days: 2)),
       createdAt: now.subtract(const Duration(days: 30)),
       updatedAt: now.subtract(const Duration(days: 5)),
-      timetable: const ActivityDaysTimetable(id: 1, description: "Harmonogram DAS"),
+      timetable: ActivityDaysTimetable(
+        id: 1,
+        description: "Harmonogram DAS",
+        entries: [
+          ActivityDaysTimetableEntry(
+            id: 1,
+            name: "Entry 1",
+            startTime: now.add(const Duration(hours: 2)),
+            // endTime: now.add(const Duration(hours: 3)),
+          ),
+          ActivityDaysTimetableEntry(
+            id: 2,
+            name: "Entry 2",
+            startTime: now.add(const Duration(hours: 4)),
+            endTime: now.add(const Duration(hours: 6)),
+          ),
+          ActivityDaysTimetableEntry(
+            id: 3,
+            name: "Entry 3",
+            startTime: now.add(const Duration(days: 1, hours: 2)),
+            endTime: now.add(const Duration(days: 1, hours: 4)),
+          ),
+        ].lock,
+      ),
       maps: const IListConst([ActivityDaysMap(id: 1, name: "Mapa główna")]),
       links: const IListConst([ActivityDaysLink(id: 1, url: "https://pwr.edu.pl")]),
       stands: const IListConst([
@@ -35,11 +58,11 @@ Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
 
   final response = await ref.getAndCacheData(
     url,
-    ActivityDaysResponse.fromJson,
+    ActivityDaysListResponse.fromJson,
     extraValidityCheck: (_) => true,
     onRetry: ref.invalidateSelf,
   );
-  final events = response.castAsList;
+  final events = response.castAsObject.data;
   if (events.isEmpty) return null;
 
   final runningEvents = events.where((e) => now.isAfter(e.startsAt) && now.isBefore(e.endsAt));

--- a/lib/features/activity_days/data/repository/activity_days_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_repository.dart
@@ -25,11 +25,7 @@ Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
         id: 1,
         description: "Harmonogram DAS",
         entries: [
-          ActivityDaysTimetableEntry(
-            id: 1,
-            name: "Entry 1",
-            startTime: now.add(const Duration(hours: 2)),
-          ),
+          ActivityDaysTimetableEntry(id: 1, name: "Entry 1", startTime: now.add(const Duration(hours: 2))),
           ActivityDaysTimetableEntry(
             id: 2,
             name: "Entry 2",

--- a/lib/features/activity_days/data/repository/activity_days_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_repository.dart
@@ -29,7 +29,6 @@ Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
             id: 1,
             name: "Entry 1",
             startTime: now.add(const Duration(hours: 2)),
-            // endTime: now.add(const Duration(hours: 3)),
           ),
           ActivityDaysTimetableEntry(
             id: 2,

--- a/lib/features/activity_days/presentation/activity_days_view.dart
+++ b/lib/features/activity_days/presentation/activity_days_view.dart
@@ -7,6 +7,7 @@ import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../widgets/horizontal_symmetric_safe_area.dart";
+import "widgets/activity_days_timetable.dart";
 
 @RoutePage()
 class ActivityDaysView extends HookConsumerWidget {
@@ -40,7 +41,7 @@ class ActivityDaysView extends HookConsumerWidget {
           Expanded(
             child: TabBarView(
               controller: tabController,
-              children: const [_PlaceholderTab(), _PlaceholderTab(), _PlaceholderTab()],
+              children: const [_PlaceholderTab(), ActivityDaysTimetable(), _PlaceholderTab()],
             ),
           ),
         ],

--- a/lib/features/activity_days/presentation/widgets/activity_days_timetable.dart
+++ b/lib/features/activity_days/presentation/widgets/activity_days_timetable.dart
@@ -1,0 +1,73 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:intl/intl.dart";
+import "package:sliver_tools/sliver_tools.dart";
+
+import "../../../../config/ui_config.dart";
+import "../../../../utils/context_extensions.dart";
+import "../../../../widgets/my_error_widget.dart";
+import "../../../../widgets/search_not_found.dart";
+import "../../../calendar/presentation/widgets/calendar_header_delegate.dart";
+import "../../../calendar/presentation/widgets/calendar_tile.dart";
+import "../../business/activity_days_timetable_use_case.dart";
+
+class ActivityDaysTimetable extends ConsumerWidget {
+  const ActivityDaysTimetable({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final timetable = ref.watch(activityDaysTimetableUseCaseProvider);
+
+    return switch (timetable) {
+      AsyncError(:final error, :final stackTrace) => MyErrorWidget(error, stackTrace: stackTrace),
+      AsyncData(:final value) => _ActivityDaysTimetableContent(days: value),
+      _ => const Center(child: CircularProgressIndicator()),
+    };
+  }
+}
+
+class _ActivityDaysTimetableContent extends StatelessWidget {
+  const _ActivityDaysTimetableContent({required this.days});
+
+  final IList<TimetableDay> days;
+
+  @override
+  Widget build(BuildContext context) {
+    if (days.isEmpty) {
+      return SearchNotFound(message: context.localize.calendar_events_not_found);
+    }
+
+    final locale = Localizations.localeOf(context).languageCode;
+
+    return CustomScrollView(
+      slivers: days.map((day) {
+        final label = DateFormat("EEEE, d MMMM", locale).format(day.date);
+        return MultiSliver(
+          pushPinnedChildren: true,
+          children: [
+            SliverPersistentHeader(
+              pinned: true,
+              delegate: CalendarHeaderDelegate(text: "${label[0].toUpperCase()}${label.substring(1)}"),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: HomeViewConfig.paddingLarge,
+                vertical: HomeViewConfig.paddingSmall,
+              ),
+              sliver: SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) => Padding(
+                    padding: const EdgeInsets.only(bottom: HomeViewConfig.paddingSmall),
+                    child: CalendarTile(day.events[index]),
+                  ),
+                  childCount: day.events.length,
+                ),
+              ),
+            ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/features/calendar/presentation/widgets/calendar_tile.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_tile.dart
@@ -19,7 +19,7 @@ class CalendarTile extends ConsumerWidget {
               children: [
                 TextSpan(
                   text: item.hoursString,
-                  style: TextStyle(fontWeight: item.hoursString.trim().contains("-") ? FontWeight.bold : null),
+                  style: TextStyle(fontWeight: item.hoursString.trim().contains(":") ? FontWeight.bold : null),
                 ),
                 if (item.location.trim().isNotEmpty) TextSpan(text: "\n${item.location}"),
               ],


### PR DESCRIPTION
I used a design similar to Calendar view and it behaves similarly to calendar in terms of different font sizes for example. It is designed to handle events across several days. In case if it will be only one day and the date text shouldn't be visible, it can be easily deleted. Also mocked a couple of entries for testing. Lacks search function, not sure if it is needed in this view.

<img width="454" height="706" alt="image" src="https://github.com/user-attachments/assets/7604df97-1026-47ac-8b4d-99d7f4b32f4d" />