### PR TITLE
feat(activity-days): add Stands list view

### DIFF
--- a/lib/features/activity_days/business/activity_days_stands_use_case.dart
+++ b/lib/features/activity_days/business/activity_days_stands_use_case.dart
@@ -1,0 +1,31 @@
+import "package:collection/collection.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../data/models/activity_days_stands_response.dart";
+import "../data/repository/activity_days_stands_repository.dart";
+
+part "activity_days_stands_use_case.g.dart";
+
+typedef StandsFloor = ({int? floorId, IList<DasStand> stands});
+
+@riverpod
+Future<IList<StandsFloor>> dasStandsByFloorUseCase(Ref ref) async {
+  final stands = await ref.watch(dasStandsRepositoryProvider.future);
+  if (stands.isEmpty) return const IListConst([]);
+
+  final byFloor = groupBy(stands.unlock, (DasStand stand) => stand.floorId);
+
+  return byFloor.entries
+      .map((floor) => (floorId: floor.key, stands: floor.value.sortedBy((stand) => stand.number).toIList()))
+      .sorted(_compareFloors)
+      .toIList();
+}
+
+int _compareFloors(StandsFloor a, StandsFloor b) {
+  final aId = a.floorId;
+  final bId = b.floorId;
+  if (aId == null) return bId == null ? 0 : 1;
+  if (bId == null) return -1;
+  return aId.compareTo(bId);
+}

--- a/lib/features/activity_days/data/models/activity_days_stands_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_stands_response.dart
@@ -1,0 +1,28 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:freezed_annotation/freezed_annotation.dart";
+
+import "../../../../api_base_rest/shared_models/image_data.dart";
+
+part "activity_days_stands_response.freezed.dart";
+part "activity_days_stands_response.g.dart";
+
+@freezed
+abstract class DasStandsListResponse with _$DasStandsListResponse {
+  const factory DasStandsListResponse(IList<DasStand> data) = _DasStandsListResponse;
+
+  factory DasStandsListResponse.fromJson(Map<String, dynamic> json) => _$DasStandsListResponseFromJson(json);
+}
+
+@freezed
+abstract class DasStand with _$DasStand {
+  const factory DasStand({
+    required int id,
+    required String number,
+    required String name,
+    String? description,
+    int? floorId,
+    ImageData? logo,
+  }) = _DasStand;
+
+  factory DasStand.fromJson(Map<String, dynamic> json) => _$DasStandFromJson(json);
+}

--- a/lib/features/activity_days/data/repository/activity_days_stands_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_stands_repository.dart
@@ -1,0 +1,22 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:riverpod_annotation/riverpod_annotation.dart";
+
+import "../../../../api_base_rest/cache/cache.dart";
+import "../../../../api_base_rest/client/json.dart";
+import "../../../../config/env.dart";
+import "../models/activity_days_stands_response.dart";
+
+part "activity_days_stands_repository.g.dart";
+
+@riverpod
+Future<IList<DasStand>> dasStandsRepository(Ref ref) async {
+  final url = "${Env.mainRestApiUrl}/das_stands";
+
+  final response = await ref.getAndCacheData(
+    url,
+    DasStandsListResponse.fromJson,
+    extraValidityCheck: (_) => true,
+    onRetry: ref.invalidateSelf,
+  );
+  return response.castAsObject.data;
+}

--- a/lib/features/activity_days/presentation/activity_days_view.dart
+++ b/lib/features/activity_days/presentation/activity_days_view.dart
@@ -7,6 +7,7 @@ import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../widgets/horizontal_symmetric_safe_area.dart";
+import "widgets/activity_days_stands.dart";
 import "widgets/activity_days_timetable.dart";
 
 @RoutePage()
@@ -41,7 +42,7 @@ class ActivityDaysView extends HookConsumerWidget {
           Expanded(
             child: TabBarView(
               controller: tabController,
-              children: const [_PlaceholderTab(), ActivityDaysTimetable(), _PlaceholderTab()],
+              children: const [ActivityDaysStands(), ActivityDaysTimetable(), _PlaceholderTab()],
             ),
           ),
         ],

--- a/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
+++ b/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
@@ -130,6 +130,9 @@ class _FloorStands extends StatelessWidget {
   }
 }
 
+// key for stands where floorId == null,
+// segmented control reserves null for no selection, so
+// _noFloorKey is set to -1, which can't collide with positive floorIds
 const _noFloorKey = -1;
 
 String _floorLabel(BuildContext context, int? floorId) =>

--- a/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
+++ b/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
@@ -1,0 +1,133 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/cupertino.dart";
+import "package:flutter/material.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../../../config/ui_config.dart";
+import "../../../../theme/app_theme.dart";
+import "../../../../utils/context_extensions.dart";
+import "../../../../widgets/my_error_widget.dart";
+import "../../../../widgets/wide_tile_card.dart";
+import "../../business/activity_days_stands_use_case.dart";
+
+class ActivityDaysStands extends ConsumerWidget {
+  const ActivityDaysStands({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final floors = ref.watch(dasStandsByFloorUseCaseProvider);
+
+    return switch (floors) {
+      AsyncError(:final error, :final stackTrace) => MyErrorWidget(error, stackTrace: stackTrace),
+      AsyncData(:final value) =>
+        value.isEmpty ? Center(child: Text(context.localize.generic_error_message)) : _StandsSection(floors: value),
+      _ => const Center(child: CircularProgressIndicator()),
+    };
+  }
+}
+
+class _StandsSection extends HookWidget {
+  const _StandsSection({required this.floors});
+
+  final IList<StandsFloor> floors;
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = useState(floors.first.floorId ?? _noFloorKey);
+
+    if (floors.length == 1) {
+      return _FloorStands(floor: floors.first);
+    }
+
+    final current = floors.firstWhere(
+      (floor) => (floor.floorId ?? _noFloorKey) == selected.value,
+      orElse: () => floors.first,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: HomeViewConfig.paddingLarge,
+            vertical: HomeViewConfig.paddingMedium,
+          ),
+          child: CupertinoSlidingSegmentedControl<int>(
+            backgroundColor: context.colorScheme.surfaceTint,
+            thumbColor: context.colorScheme.primaryContainer,
+            groupValue: selected.value,
+            onValueChanged: (value) {
+              if (value != null) selected.value = value;
+            },
+            children: {
+              for (final floor in floors)
+                (floor.floorId ?? _noFloorKey): _SegmentLabel(
+                  label: _floorLabel(context, floor.floorId),
+                  isSelected: selected.value == (floor.floorId ?? _noFloorKey),
+                ),
+            },
+          ),
+        ),
+        Expanded(child: _FloorStands(floor: current)),
+      ],
+    );
+  }
+}
+
+class _SegmentLabel extends StatelessWidget {
+  const _SegmentLabel({required this.label, required this.isSelected});
+
+  final String label;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 7),
+      child: Center(
+        child: Text(
+          label,
+          style: isSelected
+              ? context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.surface)
+              : context.textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _FloorStands extends StatelessWidget {
+  const _FloorStands({required this.floor});
+
+  final StandsFloor floor;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(
+        horizontal: HomeViewConfig.paddingLarge,
+        vertical: HomeViewConfig.paddingSmall,
+      ),
+      itemCount: floor.stands.length,
+      itemBuilder: (context, index) {
+        final stand = floor.stands[index];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: HomeViewConfig.paddingSmall),
+          child: PhotoTrailingWideTileCard(
+            context,
+            directusPhotoUrl: stand.logo,
+            title: stand.number,
+            subtitle: stand.name,
+            onTap: () {},
+          ),
+        );
+      },
+    );
+  }
+}
+
+const _noFloorKey = -1;
+
+String _floorLabel(BuildContext context, int? floorId) =>
+    floorId == null ? context.localize.nav_others : "${context.localize.level} $floorId";

--- a/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
+++ b/lib/features/activity_days/presentation/widgets/activity_days_stands.dart
@@ -40,8 +40,11 @@ class _StandsSection extends HookWidget {
       return _FloorStands(floor: floors.first);
     }
 
+    final hasSelected = floors.any((floor) => (floor.floorId ?? _noFloorKey) == selected.value);
+    final activeKey = hasSelected ? selected.value : (floors.first.floorId ?? _noFloorKey);
+
     final current = floors.firstWhere(
-      (floor) => (floor.floorId ?? _noFloorKey) == selected.value,
+      (floor) => (floor.floorId ?? _noFloorKey) == activeKey,
       orElse: () => floors.first,
     );
 
@@ -56,7 +59,7 @@ class _StandsSection extends HookWidget {
           child: CupertinoSlidingSegmentedControl<int>(
             backgroundColor: context.colorScheme.surfaceTint,
             thumbColor: context.colorScheme.primaryContainer,
-            groupValue: selected.value,
+            groupValue: activeKey,
             onValueChanged: (value) {
               if (value != null) selected.value = value;
             },
@@ -64,7 +67,7 @@ class _StandsSection extends HookWidget {
               for (final floor in floors)
                 (floor.floorId ?? _noFloorKey): _SegmentLabel(
                   label: _floorLabel(context, floor.floorId),
-                  isSelected: selected.value == (floor.floorId ?? _noFloorKey),
+                  isSelected: activeKey == (floor.floorId ?? _noFloorKey),
                 ),
             },
           ),


### PR DESCRIPTION
Looks like this for now. I followed the provided instructions and the backend model changes. Let me know if you'd like any changes, especially to the UI. I'm also not entirely sure how floors will be handled yet. Right now I'm using `floorId`, but I assume the API will return a string in production? The screenshot doesn't show the logos because the API isn't returning them yet, but they'll display correctly once they are available.

<img width="484" height="623" alt="image" src="https://github.com/user-attachments/assets/2b202076-f7b2-4191-8c24-7eefb1e8bf5d" />