### PR TITLE
feat(activity-days): new screen for map and links

### DIFF
--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -57,11 +57,7 @@ abstract class ActivityDaysTimetableEntry with _$ActivityDaysTimetableEntry {
 
 @freezed
 abstract class ActivityDaysMap with _$ActivityDaysMap {
-  const factory ActivityDaysMap({
-    required int id,
-    required String name,
-    ImageData? image,
-  }) = _ActivityDaysMap;
+  const factory ActivityDaysMap({required int id, required String name, ImageData? image}) = _ActivityDaysMap;
 
   factory ActivityDaysMap.fromJson(Map<String, dynamic> json) => _$ActivityDaysMapFromJson(json);
 }

--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -4,6 +4,8 @@ import "package:solvro_translator_core/solvro_translator_core.dart";
 
 import "../../../../api_base_rest/shared_models/image_data.dart";
 
+import "../../../../api_base_rest/shared_models/image_data.dart";
+
 part "activity_days_response.freezed.dart";
 part "activity_days_response.g.dart";
 

--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -2,6 +2,8 @@ import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:solvro_translator_core/solvro_translator_core.dart";
 
+import "../../../../api_base_rest/shared_models/image_data.dart";
+
 part "activity_days_response.freezed.dart";
 part "activity_days_response.g.dart";
 
@@ -55,14 +57,23 @@ abstract class ActivityDaysTimetableEntry with _$ActivityDaysTimetableEntry {
 
 @freezed
 abstract class ActivityDaysMap with _$ActivityDaysMap {
-  const factory ActivityDaysMap({required int id, required String name}) = _ActivityDaysMap;
+  const factory ActivityDaysMap({
+    required int id,
+    required String name,
+    ImageData? image,
+  }) = _ActivityDaysMap;
 
   factory ActivityDaysMap.fromJson(Map<String, dynamic> json) => _$ActivityDaysMapFromJson(json);
 }
 
 @freezed
 abstract class ActivityDaysLink with _$ActivityDaysLink {
-  const factory ActivityDaysLink({required int id, required String url}) = _ActivityDaysLink;
+  const factory ActivityDaysLink({
+    required int id,
+    required String url,
+    String? title,
+    String? subtitle,
+  }) = _ActivityDaysLink;
 
   factory ActivityDaysLink.fromJson(Map<String, dynamic> json) => _$ActivityDaysLinkFromJson(json);
 }

--- a/lib/features/activity_days/data/models/activity_days_response.dart
+++ b/lib/features/activity_days/data/models/activity_days_response.dart
@@ -4,8 +4,6 @@ import "package:solvro_translator_core/solvro_translator_core.dart";
 
 import "../../../../api_base_rest/shared_models/image_data.dart";
 
-import "../../../../api_base_rest/shared_models/image_data.dart";
-
 part "activity_days_response.freezed.dart";
 part "activity_days_response.g.dart";
 
@@ -72,7 +70,8 @@ abstract class ActivityDaysMap with _$ActivityDaysMap {
 abstract class ActivityDaysLink with _$ActivityDaysLink {
   const factory ActivityDaysLink({
     required int id,
-    required String url,
+    @JsonKey(name: "link") required String url,
+    String? type,
     String? title,
     String? subtitle,
   }) = _ActivityDaysLink;

--- a/lib/features/activity_days/data/repository/activity_days_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_repository.dart
@@ -1,4 +1,3 @@
-import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../api_base_rest/cache/cache.dart";
@@ -12,43 +11,7 @@ part "activity_days_repository.g.dart";
 @riverpod
 Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
   final now = DateTime.now();
-
-  if (true) {
-    return ActivityDaysResponse(
-      id: 999,
-      name: "Wiosenne Dni Aktywności Studenckiej",
-      startsAt: now.subtract(const Duration(days: 1)),
-      endsAt: now.add(const Duration(days: 2)),
-      createdAt: now.subtract(const Duration(days: 30)),
-      updatedAt: now.subtract(const Duration(days: 5)),
-      timetable: ActivityDaysTimetable(
-        id: 1,
-        description: "Harmonogram DAS",
-        entries: [
-          ActivityDaysTimetableEntry(id: 1, name: "Entry 1", startTime: now.add(const Duration(hours: 2))),
-          ActivityDaysTimetableEntry(
-            id: 2,
-            name: "Entry 2",
-            startTime: now.add(const Duration(hours: 4)),
-            endTime: now.add(const Duration(hours: 6)),
-          ),
-          ActivityDaysTimetableEntry(
-            id: 3,
-            name: "Entry 3",
-            startTime: now.add(const Duration(days: 1, hours: 2)),
-            endTime: now.add(const Duration(days: 1, hours: 4)),
-          ),
-        ].lock,
-      ),
-      maps: const IListConst([ActivityDaysMap(id: 1, name: "Mapa główna")]),
-      links: const IListConst([ActivityDaysLink(id: 1, url: "https://pwr.edu.pl")]),
-      stands: const IListConst([
-        ActivityDaysStand(id: 1, name: "Koło Naukowe Solvro"),
-        ActivityDaysStand(id: 2, name: "PWR Racing Team"),
-      ]),
-    );
-  }
-  final url = "${Env.mainRestApiUrl}/das";
+  final url = "${Env.mainRestApiUrl}/das?maps=true&links=true&maps.image=true";
 
   final response = await ref.getAndCacheData(
     url,

--- a/lib/features/activity_days/data/repository/activity_days_repository.dart
+++ b/lib/features/activity_days/data/repository/activity_days_repository.dart
@@ -1,3 +1,4 @@
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:riverpod_annotation/riverpod_annotation.dart";
 
 import "../../../../api_base_rest/cache/cache.dart";
@@ -11,6 +12,42 @@ part "activity_days_repository.g.dart";
 @riverpod
 Future<ActivityDaysResponse?> activityDaysRepository(Ref ref) async {
   final now = DateTime.now();
+
+  if (true) {
+    return ActivityDaysResponse(
+      id: 999,
+      name: "Wiosenne Dni Aktywności Studenckiej",
+      startsAt: now.subtract(const Duration(days: 1)),
+      endsAt: now.add(const Duration(days: 2)),
+      createdAt: now.subtract(const Duration(days: 30)),
+      updatedAt: now.subtract(const Duration(days: 5)),
+      timetable: ActivityDaysTimetable(
+        id: 1,
+        description: "Harmonogram DAS",
+        entries: [
+          ActivityDaysTimetableEntry(id: 1, name: "Entry 1", startTime: now.add(const Duration(hours: 2))),
+          ActivityDaysTimetableEntry(
+            id: 2,
+            name: "Entry 2",
+            startTime: now.add(const Duration(hours: 4)),
+            endTime: now.add(const Duration(hours: 6)),
+          ),
+          ActivityDaysTimetableEntry(
+            id: 3,
+            name: "Entry 3",
+            startTime: now.add(const Duration(days: 1, hours: 2)),
+            endTime: now.add(const Duration(days: 1, hours: 4)),
+          ),
+        ].lock,
+      ),
+      maps: const IListConst([ActivityDaysMap(id: 1, name: "Mapa główna")]),
+      links: const IListConst([ActivityDaysLink(id: 1, url: "https://pwr.edu.pl")]),
+      stands: const IListConst([
+        ActivityDaysStand(id: 1, name: "Koło Naukowe Solvro"),
+        ActivityDaysStand(id: 2, name: "PWR Racing Team"),
+      ]),
+    );
+  }
   final url = "${Env.mainRestApiUrl}/das";
 
   final response = await ref.getAndCacheData(

--- a/lib/features/activity_days/presentation/activity_days_view.dart
+++ b/lib/features/activity_days/presentation/activity_days_view.dart
@@ -7,8 +7,8 @@ import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../widgets/horizontal_symmetric_safe_area.dart";
-import "widgets/activity_days_stands.dart";
 import "maps_links_view.dart";
+import "widgets/activity_days_stands.dart";
 import "widgets/activity_days_timetable.dart";
 
 @RoutePage()
@@ -47,20 +47,6 @@ class ActivityDaysView extends HookConsumerWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _PlaceholderTab extends StatelessWidget {
-  const _PlaceholderTab();
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Text(
-        "Coming soon",
-        style: context.textTheme.bodyLarge?.copyWith(color: context.colorScheme.onSurface.withValues(alpha: 0.5)),
       ),
     );
   }

--- a/lib/features/activity_days/presentation/activity_days_view.dart
+++ b/lib/features/activity_days/presentation/activity_days_view.dart
@@ -8,6 +8,7 @@ import "../../../utils/context_extensions.dart";
 import "../../../widgets/detail_views/detail_view_app_bar.dart";
 import "../../../widgets/horizontal_symmetric_safe_area.dart";
 import "widgets/activity_days_stands.dart";
+import "maps_links_view.dart";
 import "widgets/activity_days_timetable.dart";
 
 @RoutePage()
@@ -42,7 +43,7 @@ class ActivityDaysView extends HookConsumerWidget {
           Expanded(
             child: TabBarView(
               controller: tabController,
-              children: const [ActivityDaysStands(), ActivityDaysTimetable(), _PlaceholderTab()],
+              children: const [ActivityDaysStands(), ActivityDaysTimetable(), MapsLinksView()],
             ),
           ),
         ],

--- a/lib/features/activity_days/presentation/maps_links_view.dart
+++ b/lib/features/activity_days/presentation/maps_links_view.dart
@@ -1,0 +1,139 @@
+import "package:auto_route/auto_route.dart";
+import "package:fast_immutable_collections/fast_immutable_collections.dart";
+import "package:flutter/cupertino.dart";
+import "package:flutter/material.dart";
+import "package:flutter_hooks/flutter_hooks.dart";
+import "package:hooks_riverpod/hooks_riverpod.dart";
+
+import "../../../theme/app_theme.dart";
+import "../../../utils/context_extensions.dart";
+import "../../../widgets/general_offline_message.dart";
+import "../data/repository/activity_days_repository.dart";
+import "widgets/link_tile.dart";
+import "widgets/map_tile.dart";
+
+@RoutePage()
+class MapsLinksView extends HookConsumerWidget {
+  const MapsLinksView({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = useState(_Tab.maps);
+    final l10n = context.localize;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: CupertinoSlidingSegmentedControl<_Tab>(
+            groupValue: selected.value,
+            backgroundColor: context.colorScheme.surfaceTint,
+            thumbColor: context.colorScheme.primaryContainer,
+            onValueChanged: (value) {
+              if (value != null) selected.value = value;
+            },
+            children: {
+              _Tab.maps: _SegmentTab(
+                label: l10n.activity_days_segment_maps,
+                isSelected: selected.value == _Tab.maps,
+              ),
+              _Tab.links: _SegmentTab(
+                label: l10n.activity_days_segment_links,
+                isSelected: selected.value == _Tab.links,
+              ),
+            },
+          ),
+        ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: selected.value == _Tab.maps ? const _MapsTab() : const _LinksTab(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+enum _Tab { maps, links }
+
+class _SegmentTab extends StatelessWidget {
+  const _SegmentTab({required this.label, required this.isSelected});
+
+  final String label;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Text(
+          label,
+          style: isSelected
+              ? context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.surface)
+              : context.textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _MapsTab extends ConsumerWidget {
+  const _MapsTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(activityDaysRepositoryProvider);
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (_, _) => _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider)),
+      data: (event) {
+        final maps = event?.maps ?? const IListConst([]);
+        if (maps.isEmpty) {
+          return _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider));
+        }
+        return ListView.builder(
+          itemCount: maps.length,
+          itemBuilder: (_, i) => MapTile(map: maps[i]),
+        );
+      },
+    );
+  }
+}
+
+class _LinksTab extends ConsumerWidget {
+  const _LinksTab();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(activityDaysRepositoryProvider);
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (_, _) => _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider)),
+      data: (event) {
+        final links = event?.links ?? const IListConst([]);
+        if (links.isEmpty) {
+          return _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider));
+        }
+        return ListView.separated(
+          itemCount: links.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 12),
+          itemBuilder: (_, i) => LinkTile(link: links[i]),
+        );
+      },
+    );
+  }
+}
+
+class _OfflineView extends StatelessWidget {
+  const _OfflineView({required this.onRefresh});
+
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return OfflineMessage(context.localize.offline_error_message, onRefresh: onRefresh);
+  }
+}

--- a/lib/features/activity_days/presentation/maps_links_view.dart
+++ b/lib/features/activity_days/presentation/maps_links_view.dart
@@ -34,10 +34,7 @@ class MapsLinksView extends HookConsumerWidget {
               if (value != null) selected.value = value;
             },
             children: {
-              _Tab.maps: _SegmentTab(
-                label: l10n.activity_days_segment_maps,
-                isSelected: selected.value == _Tab.maps,
-              ),
+              _Tab.maps: _SegmentTab(label: l10n.activity_days_segment_maps, isSelected: selected.value == _Tab.maps),
               _Tab.links: _SegmentTab(
                 label: l10n.activity_days_segment_links,
                 isSelected: selected.value == _Tab.links,

--- a/lib/features/activity_days/presentation/maps_links_view.dart
+++ b/lib/features/activity_days/presentation/maps_links_view.dart
@@ -1,5 +1,4 @@
 import "package:auto_route/auto_route.dart";
-import "package:fast_immutable_collections/fast_immutable_collections.dart";
 import "package:flutter/cupertino.dart";
 import "package:flutter/material.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
@@ -8,6 +7,7 @@ import "package:hooks_riverpod/hooks_riverpod.dart";
 import "../../../theme/app_theme.dart";
 import "../../../utils/context_extensions.dart";
 import "../../../widgets/general_offline_message.dart";
+import "../../../widgets/search_not_found.dart";
 import "../data/repository/activity_days_repository.dart";
 import "widgets/link_tile.dart";
 import "widgets/map_tile.dart";
@@ -90,9 +90,12 @@ class _MapsTab extends ConsumerWidget {
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (_, _) => _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider)),
       data: (event) {
-        final maps = event?.maps ?? const IListConst([]);
-        if (maps.isEmpty) {
+        if (event == null) {
           return _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider));
+        }
+        final maps = event.maps;
+        if (maps.isEmpty) {
+          return SearchNotFound(message: context.localize.activity_days_maps_not_found);
         }
         return ListView.builder(
           itemCount: maps.length,
@@ -113,9 +116,12 @@ class _LinksTab extends ConsumerWidget {
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (_, _) => _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider)),
       data: (event) {
-        final links = event?.links ?? const IListConst([]);
-        if (links.isEmpty) {
+        if (event == null) {
           return _OfflineView(onRefresh: () => ref.invalidate(activityDaysRepositoryProvider));
+        }
+        final links = event.links;
+        if (links.isEmpty) {
+          return SearchNotFound(message: context.localize.activity_days_links_not_found);
         }
         return ListView.separated(
           itemCount: links.length,

--- a/lib/features/activity_days/presentation/widgets/link_tile.dart
+++ b/lib/features/activity_days/presentation/widgets/link_tile.dart
@@ -1,0 +1,50 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:flutter_svg/flutter_svg.dart";
+
+import "../../../../config/ui_config.dart";
+import "../../../../utils/context_extensions.dart";
+import "../../../../utils/determine_contact_icon.dart";
+import "../../../../utils/launch_url_util.dart";
+import "../../../../widgets/wide_tile_card.dart";
+import "../../data/models/activity_days_response.dart";
+
+class LinkTile extends ConsumerWidget {
+  const LinkTile({required this.link, super.key});
+
+  final ActivityDaysLink link;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final title = link.title ?? _hostFromUrl(link.url);
+    final subtitle = link.subtitle ?? link.url;
+    final iconPath = link.url.determineIcon();
+
+    return Semantics(
+      label: "$title, $subtitle",
+      button: true,
+      child: WideTileCard(
+        title: title,
+        subtitle: subtitle,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        onTap: () => ref.launch(link.url),
+        trailing: SizedBox(
+          height: context.textScaler.clamp(maxScaleFactor: 2).scale(WideTileCardConfig.imageSize),
+          width: WideTileCardConfig.imageSize,
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: SvgPicture.asset(iconPath, semanticsLabel: title),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _hostFromUrl(String url) {
+    try {
+      return Uri.parse(url).host.replaceFirst(RegExp(r"^www\."), "");
+    } on FormatException {
+      return url;
+    }
+  }
+}

--- a/lib/features/activity_days/presentation/widgets/link_tile.dart
+++ b/lib/features/activity_days/presentation/widgets/link_tile.dart
@@ -18,7 +18,7 @@ class LinkTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final title = link.title ?? _hostFromUrl(link.url);
     final subtitle = link.subtitle ?? link.url;
-    final iconPath = link.url.determineIcon();
+    final iconPath = (link.type ?? link.url).determineIcon();
 
     return Semantics(
       label: "$title, $subtitle",

--- a/lib/features/activity_days/presentation/widgets/map_tile.dart
+++ b/lib/features/activity_days/presentation/widgets/map_tile.dart
@@ -1,0 +1,38 @@
+import "package:flutter/material.dart";
+
+import "../../../../config/ui_config.dart";
+import "../../../../widgets/my_expansion_tile.dart";
+import "../../../../widgets/zoomable_images.dart";
+import "../../data/models/activity_days_response.dart";
+
+class MapTile extends StatelessWidget {
+  const MapTile({required this.map, super.key});
+
+  final ActivityDaysMap map;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: MyExpansionTile(
+        title: map.name,
+        initiallyExpanded: true,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(DigitalGuideConfig.paddingMedium),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
+              child: AspectRatio(
+                aspectRatio: 4 / 3,
+                child: ZoomableRestApiImage(
+                  map.image,
+                  semanticsLabel: map.name,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/activity_days/presentation/widgets/map_tile.dart
+++ b/lib/features/activity_days/presentation/widgets/map_tile.dart
@@ -24,10 +24,7 @@ class MapTile extends StatelessWidget {
               borderRadius: BorderRadius.circular(DigitalGuideConfig.borderRadiusMedium),
               child: AspectRatio(
                 aspectRatio: 4 / 3,
-                child: ZoomableRestApiImage(
-                  map.image,
-                  semanticsLabel: map.name,
-                ),
+                child: ZoomableRestApiImage(map.image, semanticsLabel: map.name),
               ),
             ),
           ),

--- a/lib/features/navigator/app_router.dart
+++ b/lib/features/navigator/app_router.dart
@@ -6,6 +6,7 @@ import "../../config/nav_bar_config.dart";
 import "../about_us_view/about_us_view.dart";
 import "../activity_days/presentation/activity_days_stand_detail_view.dart";
 import "../activity_days/presentation/activity_days_view.dart";
+import "../activity_days/presentation/maps_links_view.dart";
 import "../booths/presentation/booths_view.dart";
 import "../calendar/presentation/calendar_view.dart";
 import "../departments/department_detail_view/presentation/department_detail_view.dart";

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -693,6 +693,8 @@
   "activity_days_tab_stands": "Stands",
   "activity_days_tab_timetable": "Timetable",
   "activity_days_tab_info": "Information",
+  "activity_days_segment_maps": "Map",
+  "activity_days_segment_links": "Links",
   "activity_days_stand_number": "Stand {number}",
   "activity_days_stand_description": "About the stand",
   "activity_days_stand_organization": "Organization",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -695,6 +695,8 @@
   "activity_days_tab_info": "Information",
   "activity_days_segment_maps": "Map",
   "activity_days_segment_links": "Links",
+  "activity_days_maps_not_found": "No maps found",
+  "activity_days_links_not_found": "No links found",
   "activity_days_stand_number": "Stand {number}",
   "activity_days_stand_description": "About the stand",
   "activity_days_stand_organization": "Organization",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3928,6 +3928,14 @@
   "@activity_days_segment_links": {
     "description": "Segmented control label for links subtab in Activity Days"
   },
+  "activity_days_maps_not_found": "Nie znaleziono map",
+  "@activity_days_maps_not_found": {
+    "description": "Empty state when Activity Days has no maps"
+  },
+  "activity_days_links_not_found": "Nie znaleziono linków",
+  "@activity_days_links_not_found": {
+    "description": "Empty state when Activity Days has no links"
+  },
   "activity_days_stand_number": "Stoisko {number}",
   "@activity_days_stand_number": {
     "description": "Label containing an Activity Days stand number",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -3920,6 +3920,14 @@
   "@activity_days_tab_info": {
     "description": "Tab label for information section in Activity Days"
   },
+  "activity_days_segment_maps": "Mapa",
+  "@activity_days_segment_maps": {
+    "description": "Segmented control label for maps subtab in Activity Days"
+  },
+  "activity_days_segment_links": "Linki",
+  "@activity_days_segment_links": {
+    "description": "Segmented control label for links subtab in Activity Days"
+  },
   "activity_days_stand_number": "Stoisko {number}",
   "@activity_days_stand_number": {
     "description": "Label containing an Activity Days stand number",


### PR DESCRIPTION
### Summary
UI preview of the **Information** tab in Activity Days - maps and links.  
Data is **hardcoded** (mock in the repo), backend **not tested yet**.

### Screenshots
| Maps | Links |
|------|-------|
| ![Maps](https://github.com/user-attachments/assets/ae162fb2-a8b2-44fc-b109-9f5a300334bc) | ![Links](https://github.com/user-attachments/assets/1281debc-b698-49c6-9129-d5080b3221cc) |

### What's in the preview
- Segmented control **Map / Links**
- Maps as expansion tiles (expanded by default), tap → fullscreen
- Links as wide tile cards with link-type icon on the right