### PR TITLE
fix(sci-clubs): filters with haptic feedback and tags filtering

### DIFF
--- a/lib/features/science_club/science_clubs_filters/filters_sheet.dart
+++ b/lib/features/science_club/science_clubs_filters/filters_sheet.dart
@@ -69,7 +69,7 @@ class FiltersSheet extends ConsumerWidget {
                                 icon: Icons.close,
                                 onPressed: ref.watch(areFiltersEnabledProvider)
                                     ? () {
-                                        ref.getClearAllFilters(ref);
+                                        ref.getClearAllFilters(ref)();
                                       }
                                     : () {},
                                 isSecondary: true,

--- a/lib/features/science_club/science_clubs_filters/widgets/filter_chip.dart
+++ b/lib/features/science_club/science_clubs_filters/widgets/filter_chip.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:flutter/material.dart";
 import "package:hooks_riverpod/hooks_riverpod.dart";
 
@@ -41,10 +39,7 @@ class MyFilterChip extends HookConsumerWidget {
           showCheckmark: false,
           label: Text(label),
           selected: selected,
-          onSelected: (_) {
-            unawaited(AppHaptics.selectionClick());
-            onTap();
-          },
+          onSelected: (_) => AppHaptics.wrapperSelection(onTap)?.call(),
           selectedColor: selectedColor ?? context.colorScheme.primary,
           backgroundColor: Colors.transparent,
           labelStyle: TextStyle(color: selected ? context.colorScheme.onPrimary : context.colorScheme.tertiary),

--- a/lib/features/science_club/science_clubs_view/controllers/science_clubs_view_controller.dart
+++ b/lib/features/science_club/science_clubs_view/controllers/science_clubs_view_controller.dart
@@ -70,7 +70,7 @@ Future<IList<ScienceClub>> scienceClubsListController(Ref ref) async {
 
   final filteredByTags = selectedTags.isEmpty
       ? filteredByDepartments
-      : filteredByDepartments.where((club) => club.tags.whereNonNull.any(selectedTags.contains));
+      : filteredByDepartments.where((club) => club.tags.whereNonNull.any((tag) => selectedTags.contains(tag.tag)));
 
   final filteredByBranches = selectedBranches.isEmpty
       ? filteredByTags


### PR DESCRIPTION
The buttons weren't working because some functions weren't being called properly. The wrapper looks fine, but it needs to be used carefully, especially with anonymous functions. I didn't find any other issues of this type beyond the ones I fixed. I also noticed that filtering by tags wasn't returning any results.

On my device (Samsung Galaxy A40, Android 11.0), the haptics used in the code don't work (only HapticFeedback.vibrate() does). I'm not sure what causes this, according to the documentation they should work on Android API level 23+. I replaced the non-working haptic methods with HapticFeedback.vibrate() during tests. The other haptic methods may require additional testing (I don't think so, they are called correctly, only the type changes). This could potentially also affect users.