### PR TITLE
fix(sks-menu): single click on menu position shoudn't trigger haptics

### DIFF
--- a/lib/features/sks/sks_menu/presentation/widgets/sks_menu_tiles.dart
+++ b/lib/features/sks/sks_menu/presentation/widgets/sks_menu_tiles.dart
@@ -90,8 +90,8 @@ class SksMenuDishDetailsTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final hasIncreasedTextSize = context.isTextScaledUp;
     final baseTile = GestureDetector(
-      onTap: !kIsWeb ? AppHaptics.wrapperSelection(() => onTap?.call(dish.id)) : null,
-      onDoubleTap: !kIsWeb ? () => onDoubleTap?.call(dish.id) : null,
+      onTap: !kIsWeb && onTap != null ? AppHaptics.wrapperSelection(() => onTap!(dish.id)) : null,
+      onDoubleTap: !kIsWeb && onDoubleTap != null ? AppHaptics.wrapperSelection(() => onDoubleTap!(dish.id)) : null,
       child: Material(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(SksMenuConfig.borderRadius),


### PR DESCRIPTION
Haptics are triggered only on action, including a double tap in sks menu (not sure if this is desired).